### PR TITLE
Adding GPU device to docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,13 @@ services:
     command: sleep infinity
     networks:
       llm-network:
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            capabilities: ["gpu"]
+            count: all
 
 networks:
   llm-network:


### PR DESCRIPTION
We need to expose the GPU to be able to use it, it appears.