### PR TITLE
Add Agent OS commands and product documentation

### DIFF
--- a/.claude/commands/agent-os/discover-standards.md
+++ b/.claude/commands/agent-os/discover-standards.md
@@ -1,0 +1,261 @@
+# Discover Standards
+
+Extract tribal knowledge from your codebase into concise, documented standards.
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Write concise standards** — Use minimal words. Standards must be scannable by AI agents without bloating context windows.
+- **Offer suggestions** — Present options the user can confirm, choose between, or correct. Don't make them think harder than necessary.
+
+## Process
+
+### Step 1: Determine Focus Area
+
+Check if the user specified an area when running this command. If they did, skip to Step 2.
+
+If no area was specified:
+
+1. Analyze the codebase structure (folders, file types, patterns)
+2. Identify 3-5 major areas. Examples:
+   - **Frontend areas:** UI components, styling/CSS, state management, forms, routing
+   - **Backend areas:** API routes, database/models, authentication, background jobs
+   - **Cross-cutting:** Error handling, validation, testing, naming conventions, file structure
+3. Use AskUserQuestion to present the areas:
+
+```
+I've identified these areas in your codebase:
+
+1. **API Routes** (src/api/) — Request handling, response formats
+2. **Database** (src/models/, src/db/) — Models, queries, migrations
+3. **React Components** (src/components/) — UI patterns, props, state
+4. **Authentication** (src/auth/) — Login, sessions, permissions
+
+Which area should we focus on for discovering standards? (Pick one, or suggest a different area)
+```
+
+Wait for user response before proceeding.
+
+### Step 2: Analyze & Present Findings
+
+Once an area is determined:
+
+1. Read key files in that area (5-10 representative files)
+2. Look for patterns that are:
+   - **Unusual or unconventional** — Not standard framework/library patterns
+   - **Opinionated** — Specific choices that could have gone differently
+   - **Tribal** — Things a new developer wouldn't know without being told
+   - **Consistent** — Patterns repeated across multiple files
+
+3. Use AskUserQuestion to present findings and let user select:
+
+```
+I analyzed [area] and found these potential standards worth documenting:
+
+1. **API Response Envelope** — All responses use { success, data, error } structure
+2. **Error Codes** — Custom error codes like AUTH_001, DB_002 with specific meanings
+3. **Pagination Pattern** — Cursor-based pagination with consistent param names
+
+Which would you like to document?
+
+Options:
+- "Yes, all of them"
+- "Just 1 and 3"
+- "Add: [your suggestion]"
+- "Skip this area"
+```
+
+Wait for user selection before proceeding.
+
+### Step 3: Ask Why, Then Draft Each Standard
+
+**IMPORTANT:** For each selected standard, you MUST complete this full loop before moving to the next standard:
+
+1. **Ask 1-2 clarifying questions** about the "why" behind the pattern. Use your AskUserQuestion tool for this.
+2. **Wait for user response**
+3. **Draft the standard** incorporating their answer
+4. **Confirm with user** before creating the file
+5. **Create the file** if approved
+
+Example questions to ask (adapt based on the specific standard):
+
+- "What problem does this pattern solve? Why not use the default/common approach?"
+- "Are there exceptions where this pattern shouldn't be used?"
+- "What's the most common mistake a developer or agent makes with this?"
+
+**Do NOT batch all questions upfront.** Process one standard at a time through the full loop.
+
+### Step 4: Create the Standard File
+
+For each standard (after completing Step 3's Q&A):
+
+1. Determine the appropriate folder (create if needed):
+   - `api/`, `database/`, `javascript/`, `css/`, `backend/`, `testing/`, `global/`
+
+2. Check if a related standard file already exists — append to it if so
+
+3. Draft the content and use AskUserQuestion to confirm:
+
+```
+Here's the draft for api/response-format.md:
+
+---
+# API Response Format
+
+All API responses use this envelope:
+
+\`\`\`json
+{ "success": true, "data": { ... } }
+{ "success": false, "error": { "code": "...", "message": "..." } }
+\`\`\`
+
+- Never return raw data without the envelope
+- Error responses must include both code and message
+- Success responses omit the error field entirely
+---
+
+Create this file? (yes / edit: [your changes] / skip)
+```
+
+4. Create or update the file in `agent-os/standards/[folder]/`
+5. **Then repeat Steps 3-4 for the next selected standard**
+
+### Step 5: Update the Index
+
+After all standards are created:
+
+1. Scan `agent-os/standards/` for all `.md` files
+2. For each new file without an index entry, use AskUserQuestion:
+
+```
+New standard needs an index entry:
+  File: api/response-format.md
+
+Suggested description: "API response envelope structure and error format"
+
+Accept this description? (yes / or type a better one)
+```
+
+3. Update `agent-os/standards/index.yml`:
+
+```yaml
+api:
+  response-format:
+    description: API response envelope structure and error format
+```
+
+Alphabetize by folder, then by filename.
+
+### Step 6: Offer to Continue
+
+Use AskUserQuestion:
+
+```
+Standards created for [area]:
+- api/response-format.md
+- api/error-codes.md
+
+Would you like to discover standards in another area, or are we done?
+```
+
+## Output Location
+
+All standards: `agent-os/standards/[folder]/[standard].md`
+Index file: `agent-os/standards/index.yml`
+
+## Writing Concise Standards
+
+Standards will be injected into AI context windows. Every word costs tokens. Follow these rules:
+
+- **Lead with the rule** — State what to do first, explain why second (if needed)
+- **Use code examples** — Show, don't tell
+- **Skip the obvious** — Don't document what the code already makes clear
+- **One standard per concept** — Don't combine unrelated patterns
+- **Bullet points over paragraphs** — Scannable beats readable
+
+**Good:**
+```markdown
+# Error Responses
+
+Use error codes: `AUTH_001`, `DB_001`, `VAL_001`
+
+\`\`\`json
+{ "success": false, "error": { "code": "AUTH_001", "message": "..." } }
+\`\`\`
+
+- Always include both code and message
+- Log full error server-side, return safe message to client
+```
+
+**Bad:**
+```markdown
+# Error Handling Guidelines
+
+When an error occurs in our application, we have established a consistent pattern for how errors should be formatted and returned to the client. This helps maintain consistency across our API and makes it easier for frontend developers to handle errors appropriately...
+[continues for 3 more paragraphs]
+```
+
+## Example: Full Loop for One Standard
+
+Here's how to process a single standard through the complete workflow:
+
+**1. Present findings (Step 2):**
+```
+I found these patterns in your API code:
+1. **Response Envelope** — All responses use { success, data, error }
+2. **Error Codes** — Custom codes like AUTH_001
+
+Which would you like to document?
+```
+
+User: "Both"
+
+**2. Ask why for first standard (Step 3):**
+```
+For the Response Envelope pattern:
+- What problem does this solve? Why not return raw data?
+- Are there any endpoints that don't use this pattern?
+```
+
+User: "We use it so the frontend always knows where to find the data. All endpoints use it, no exceptions."
+
+**3. Draft first standard (Step 3 continued):**
+```
+Here's the draft for api/response-envelope.md:
+
+---
+# Response Envelope
+
+All API responses use this structure:
+\`\`\`json
+{ "success": true, "data": { ... } }
+{ "success": false, "error": { ... } }
+\`\`\`
+
+- Frontend always checks `success` first, then reads `data` or `error`
+- No exceptions — every endpoint uses this format
+---
+
+Create this file?
+```
+
+User: "Yes"
+
+**4. Create file, then move to next standard:**
+
+[Create the file]
+
+**5. Ask why for second standard (back to Step 3):**
+```
+For the Error Codes pattern:
+- What's the naming convention for codes?
+- Where should new error codes be documented?
+```
+
+User: "Format is AREA_NUMBER like AUTH_001. We keep a list in the wiki."
+
+**6. Draft second standard, confirm, create file...**
+
+[Continue until all selected standards are done]
+
+**Key point:** Complete the full ask → draft → confirm → create cycle for each standard before starting the next one.

--- a/.claude/commands/agent-os/index-standards.md
+++ b/.claude/commands/agent-os/index-standards.md
@@ -1,0 +1,124 @@
+# Index Standards
+
+Rebuild and maintain the standards index file (`index.yml`).
+
+## Purpose
+
+The index enables `/inject-standards` to suggest relevant standards without reading all files. It maps each standard to a brief description for quick matching.
+
+## Process
+
+### Step 1: Scan for Standards Files
+
+1. List all `.md` files in `agent-os/standards/` and its subfolders
+2. Build a list of all standards organized by folder:
+   ```
+   root/coding-style.md        # Files in standards/ root use "root" as the folder name
+   root/naming.md
+   api/response-format.md
+   api/error-handling.md
+   database/migrations.md
+   ```
+
+**Note:** `root` is a reserved keyword — it refers to `.md` files directly in `agent-os/standards/` (not in a subfolder). Do not create an actual folder named "root".
+
+### Step 2: Load Existing Index
+
+Read `agent-os/standards/index.yml` if it exists. Note which entries already have descriptions.
+
+### Step 3: Identify Changes
+
+Compare the file scan with the existing index:
+
+- **New files** — Standards files without index entries
+- **Deleted files** — Index entries for files that no longer exist
+- **Existing files** — Already indexed, keep as-is
+
+### Step 4: Handle New Files
+
+For each new standard file that needs an index entry:
+
+1. Read the file to understand its content
+2. Use AskUserQuestion to propose a description:
+
+```
+New standard needs indexing:
+  File: api/response-format.md
+
+Suggested description: "API response envelope structure and error format"
+
+Accept? (yes / or type a better description)
+```
+
+Keep descriptions to **one short sentence** — they're for matching, not documentation.
+
+### Step 5: Handle Deleted Files
+
+If there are index entries for files that no longer exist:
+
+1. List them for the user
+2. Remove them from the index automatically (no confirmation needed)
+
+Report: "Removed 2 stale index entries: api/old-pattern.md, testing/deprecated.md"
+
+### Step 6: Write Updated Index
+
+Generate `agent-os/standards/index.yml` with this structure:
+
+```yaml
+folder-name:
+  file-name:
+    description: Brief description here
+```
+
+**Rules:**
+- Alphabetize folders
+- Alphabetize files within each folder
+- File names without `.md` extension
+- One-line descriptions only
+
+**Example:**
+```yaml
+root:
+  coding-style:
+    description: General coding style, formatting, linting rules
+  naming:
+    description: File naming, variable naming, class naming conventions
+
+api:
+  error-handling:
+    description: Error codes, exception handling, error response format
+  response-format:
+    description: API response envelope structure, status codes, pagination
+
+database:
+  migrations:
+    description: Migration file structure, naming conventions, rollback patterns
+```
+
+**Note:** `root` appears first and contains standards files that live directly in `agent-os/standards/` (not in subfolders).
+
+### Step 7: Report Results
+
+Summarize what changed:
+
+```
+Index updated:
+  ✓ 2 new entries added
+  ✓ 1 stale entry removed
+  ✓ 8 entries unchanged
+
+Total: 9 standards indexed
+```
+
+## When to Run
+
+- After manually creating or deleting standards files
+- If `/inject-standards` suggestions seem out of sync
+- To clean up a messy or outdated index
+
+**Note:** `/discover-standards` runs this automatically as its final step, so you usually don't need to call it separately after discovering standards.
+
+## Output
+
+Updates `agent-os/standards/index.yml`

--- a/.claude/commands/agent-os/inject-standards.md
+++ b/.claude/commands/agent-os/inject-standards.md
@@ -1,0 +1,291 @@
+# Inject Standards
+
+Inject relevant standards into the current context, formatted appropriately for the situation.
+
+## Usage Modes
+
+This command supports two modes:
+
+### Auto-Suggest Mode (no arguments)
+```
+/inject-standards
+```
+Analyzes context and suggests relevant standards.
+
+### Explicit Mode (with arguments)
+```
+/inject-standards api                           # All standards in api/
+/inject-standards api/response-format           # Single file
+/inject-standards api/response-format api/auth  # Multiple files
+/inject-standards root                          # All standards in the root folder
+/inject-standards root/naming                   # Single file from root folder
+```
+Directly injects specified standards without suggestions.
+
+**Note:** `root` is a reserved keyword — it refers to `.md` files directly in `agent-os/standards/` (not in a subfolder).
+
+## Process
+
+### Step 1: Detect Context Scenario
+
+Before injecting standards, determine which scenario we're in. Read the current conversation and check if we're in plan mode.
+
+**Three scenarios:**
+
+1. **Conversation** — Regular chat, implementing code, answering questions
+2. **Creating a Skill** — Building a `.claude/skills/` file
+3. **Shaping/Planning** — In plan mode, building a spec, running `/shape-spec`
+
+**Detection logic:**
+
+- If currently in plan mode OR conversation clearly mentions "spec", "plan", "shape" → **Shaping/Planning**
+- If conversation clearly mentions creating a skill, editing `.claude/skills/`, or building a reusable procedure → **Creating a Skill**
+- Otherwise → **Ask to confirm** (do not assume)
+
+**If neither skill nor plan is clearly detected**, use AskUserQuestion to confirm:
+
+```
+I'll inject the relevant standards. How should I format them?
+
+1. **Conversation** — Read standards into our chat (for implementation work)
+2. **Skill** — Output file references to include in a skill you're building
+3. **Plan** — Output file references to include in a plan/spec
+
+Which scenario? (1, 2, or 3)
+```
+
+Always ask when uncertain — don't assume conversation by default.
+
+### Step 2: Read the Index (Auto-Suggest Mode)
+
+Read `agent-os/standards/index.yml` to get the list of available standards and their descriptions.
+
+If index.yml doesn't exist or is empty:
+```
+No standards index found. Run /discover-standards first to create standards,
+or /index-standards if you have standards files without an index.
+```
+
+### Step 3: Analyze Work Context
+
+Look at the current conversation to understand what the user is working on:
+- What type of work? (API, database, UI, etc.)
+- What technologies mentioned?
+- What's the goal?
+
+### Step 4: Match and Suggest
+
+Match index descriptions against the context. Use AskUserQuestion to present suggestions:
+
+```
+Based on your task, these standards may be relevant:
+
+1. **api/response-format** — API response envelope structure, status codes
+2. **api/error-handling** — Error codes, exception handling, error responses
+3. **global/naming** — File naming, variable naming conventions
+
+Inject these standards? (yes / just 1 and 3 / add: database/migrations / none)
+```
+
+Keep suggestions focused — typically 2-5 standards. Don't overwhelm with too many options.
+
+### Step 5: Inject Based on Scenario
+
+Format the output differently based on the detected scenario:
+
+---
+
+#### Scenario: Conversation
+
+Read the standards and announce them:
+
+```
+I've read the following standards as they are relevant to what we're working on:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+**Key points:**
+- All API responses use { success, data, error } envelope
+- Error codes follow AUTH_xxx, DB_xxx pattern
+```
+
+---
+
+#### Scenario: Creating a Skill
+
+First, use AskUserQuestion to determine how to include the standards:
+
+```
+How should these standards be included in your skill?
+
+1. **References** — Add @ file paths that point to the standards (keeps skill lightweight, standards stay in sync)
+2. **Copy content** — Paste the full standards content into the skill (self-contained, but won't update if standards change)
+
+Which approach? (1 or 2)
+```
+
+**If References (option 1):**
+
+```
+Be sure to include references to the following standards files in the appropriate location in the file(s) that make up this skill:
+
+@agent-os/standards/api/response-format.md
+@agent-os/standards/api/error-handling.md
+@agent-os/standards/global/naming.md
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+**If Copy content (option 2):**
+
+```
+Include the following standards content in your skill:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+---
+
+#### Scenario: Shaping/Planning
+
+First, use AskUserQuestion to determine how to include the standards:
+
+```
+How should these standards be included in your plan?
+
+1. **References** — Add @ file paths that point to the standards (keeps plan lightweight, standards stay in sync)
+2. **Copy content** — Paste the full standards content into the plan (self-contained, but won't update if standards change)
+
+Which approach? (1 or 2)
+```
+
+**If References (option 1):**
+
+```
+Be sure to include references to the following standards files in the appropriate location in the plan we're building:
+
+@agent-os/standards/api/response-format.md
+@agent-os/standards/api/error-handling.md
+@agent-os/standards/global/naming.md
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+**If Copy content (option 2):**
+
+```
+Include the following standards content in your plan:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+---
+
+### Step 6: Surface Related Skills (Conversation scenario only)
+
+When in conversation scenario, check if `.claude/skills/` exists and contains related skills:
+
+```
+Related Skills you might want to use:
+- create-api-endpoint — Scaffolds new API endpoints following these standards
+```
+
+Don't invoke skills automatically — just surface them for awareness.
+
+---
+
+## Explicit Mode
+
+When arguments are provided, skip the suggestion step but still detect scenario.
+
+### Step 1: Detect Scenario
+
+Same as auto-suggest mode.
+
+### Step 2: Parse Arguments
+
+Arguments can be:
+- **Folder name** — `api` → inject all `.md` files in `agent-os/standards/api/`
+- **Folder/file** — `api/response-format` → inject `agent-os/standards/api/response-format.md`
+- **Root folder** — `root` → inject all `.md` files directly in `agent-os/standards/` (not in subfolders)
+- **Root file** — `root/naming` → inject `agent-os/standards/naming.md`
+
+Multiple arguments inject multiple standards.
+
+### Step 3: Validate
+
+Check that specified files/folders exist. If not:
+
+```
+Standard not found: api/nonexistent
+
+Available standards in api/:
+- response-format
+- error-handling
+- authentication
+
+Did you mean one of these?
+```
+
+### Step 4: Inject Based on Scenario
+
+Same formatting as auto-suggest mode, based on detected scenario.
+
+---
+
+## Tips
+
+- **Run early** — Inject standards at the start of a task, before implementation
+- **Be specific** — If you know which standards apply, use explicit mode
+- **Check the index** — If suggestions seem wrong, run `/index-standards` to rebuild
+- **Keep standards concise** — Injected standards consume tokens; shorter is better
+
+## Integration
+
+This command is called internally by `/shape-spec` to inject relevant standards during planning. You can also invoke it directly anytime you need standards in context.

--- a/.claude/commands/agent-os/plan-product.md
+++ b/.claude/commands/agent-os/plan-product.md
@@ -1,0 +1,204 @@
+# Plan Product
+
+Establish foundational product documentation through an interactive conversation. Creates mission, roadmap, and tech stack files in `agent-os/product/`.
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Keep it lightweight** — gather enough to create useful docs without over-documenting
+- **One question at a time** — don't overwhelm with multiple questions
+
+## Process
+
+### Step 1: Check for Existing Product Docs
+
+Check if `agent-os/product/` exists and contains any of these files:
+- `mission.md`
+- `roadmap.md`
+- `tech-stack.md`
+
+**If any files exist**, use AskUserQuestion:
+
+```
+I found existing product documentation:
+- mission.md: [exists/missing]
+- roadmap.md: [exists/missing]
+- tech-stack.md: [exists/missing]
+
+Would you like to:
+1. Start fresh (replace all)
+2. Update specific files
+3. Cancel
+
+(Choose 1, 2, or 3)
+```
+
+If option 2, ask which files to update and only gather info for those.
+If option 3, stop here.
+
+**If no files exist**, proceed to Step 2.
+
+### Step 2: Gather Product Vision (for mission.md)
+
+Use AskUserQuestion:
+
+```
+Let's define your product's mission.
+
+**What problem does this product solve?**
+
+(Describe the core problem or pain point you're addressing)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**Who is this product for?**
+
+(Describe your target users or audience)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**What makes your solution unique?**
+
+(What's the key differentiator or approach?)
+```
+
+### Step 3: Gather Roadmap (for roadmap.md)
+
+Use AskUserQuestion:
+
+```
+Now let's outline your development roadmap.
+
+**What are the must-have features for launch (MVP)?**
+
+(List the core features needed for the first usable version)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**What features are planned for after launch?**
+
+(List features you'd like to add in future phases, or say "none yet")
+```
+
+### Step 4: Establish Tech Stack (for tech-stack.md)
+
+First, check if `agent-os/standards/global/tech-stack.md` exists.
+
+**If the tech-stack standard exists**, read it and use AskUserQuestion:
+
+```
+I found a tech stack standard in your standards:
+
+[Summarize the key technologies from global/tech-stack.md]
+
+Does this project use the same tech stack, or does it differ?
+
+1. Same as standard (use as-is)
+2. Different (I'll specify)
+
+(Choose 1 or 2)
+```
+
+If they choose option 1, use the standard's content for tech-stack.md.
+If they choose option 2, proceed to ask them to specify (see below).
+
+**If no tech-stack standard exists** (or they chose option 2 above), use AskUserQuestion:
+
+```
+**What technologies does this project use?**
+
+Please describe your tech stack:
+- Frontend: (e.g., React, Vue, vanilla JS, or N/A)
+- Backend: (e.g., Rails, Node, Django, or N/A)
+- Database: (e.g., PostgreSQL, MongoDB, or N/A)
+- Other: (hosting, APIs, tools, etc.)
+```
+
+### Step 5: Generate Files
+
+Create the `agent-os/product/` directory if it doesn't exist.
+
+Generate each file based on the information gathered:
+
+#### mission.md
+
+```markdown
+# Product Mission
+
+## Problem
+
+[Insert what problem this product solves - from Step 2]
+
+## Target Users
+
+[Insert who this product is for - from Step 2]
+
+## Solution
+
+[Insert what makes the solution unique - from Step 2]
+```
+
+#### roadmap.md
+
+```markdown
+# Product Roadmap
+
+## Phase 1: MVP
+
+[Insert must-have features for launch - from Step 3]
+
+## Phase 2: Post-Launch
+
+[Insert planned future features - from Step 3, or "To be determined" if they said none yet]
+```
+
+#### tech-stack.md
+
+```markdown
+# Tech Stack
+
+[Organize the tech stack information into logical sections]
+
+## Frontend
+
+[Frontend technologies, or "N/A" if not applicable]
+
+## Backend
+
+[Backend technologies, or "N/A" if not applicable]
+
+## Database
+
+[Database choice, or "N/A" if not applicable]
+
+## Other
+
+[Other tools, hosting, services - or omit this section if nothing mentioned]
+```
+
+### Step 6: Confirm Completion
+
+After creating all files, output to user:
+
+```
+✓ Product documentation created:
+
+  agent-os/product/mission.md
+  agent-os/product/roadmap.md
+  agent-os/product/tech-stack.md
+
+Review these files to ensure they accurately capture your product vision.
+You can edit them directly or run /plan-product again to update.
+```
+
+## Tips
+
+- If the user provides very brief answers, that's fine — the docs can be expanded later
+- If they want to skip a section, create the file with a placeholder like "To be defined"
+- The `/shape-spec` command will read these files when planning features, so having them populated helps with context

--- a/.claude/commands/agent-os/shape-spec.md
+++ b/.claude/commands/agent-os/shape-spec.md
@@ -1,0 +1,267 @@
+# Shape Spec
+
+Gather context and structure planning for significant work. **Run this command while in plan mode.**
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Offer suggestions** — Present options the user can confirm, adjust, or correct
+- **Keep it lightweight** — This is shaping, not exhaustive documentation
+
+## Prerequisites
+
+This command **must be run in plan mode**.
+
+**Before proceeding, check if you are currently in plan mode.**
+
+If NOT in plan mode, **stop immediately** and tell the user:
+
+```
+Shape-spec must be run in plan mode. Please enter plan mode first, then run /shape-spec again.
+```
+
+Do not proceed with any steps below until confirmed to be in plan mode.
+
+## Process
+
+### Step 1: Clarify What We're Building
+
+Use AskUserQuestion to understand the scope:
+
+```
+What are we building? Please describe the feature or change.
+
+(Be as specific as you like — I'll ask follow-up questions if needed)
+```
+
+Based on their response, ask 1-2 clarifying questions if the scope is unclear. Examples:
+- "Is this a new feature or a change to existing functionality?"
+- "What's the expected outcome when this is done?"
+- "Are there any constraints or requirements I should know about?"
+
+### Step 2: Gather Visuals
+
+Use AskUserQuestion:
+
+```
+Do you have any visuals to reference?
+
+- Mockups or wireframes
+- Screenshots of similar features
+- Examples from other apps
+
+(Paste images, share file paths, or say "none")
+```
+
+If visuals are provided, note them for inclusion in the spec folder.
+
+### Step 3: Identify Reference Implementations
+
+Use AskUserQuestion:
+
+```
+Is there similar code in this codebase I should reference?
+
+Examples:
+- "The comments feature is similar to what we're building"
+- "Look at how src/features/notifications/ handles real-time updates"
+- "No existing references"
+
+(Point me to files, folders, or features to study)
+```
+
+If references are provided, read and analyze them to inform the plan.
+
+### Step 4: Check Product Context
+
+Check if `agent-os/product/` exists and contains files.
+
+If it exists, read key files (like `mission.md`, `roadmap.md`, `tech-stack.md`) and use AskUserQuestion:
+
+```
+I found product context in agent-os/product/. Should this feature align with any specific product goals or constraints?
+
+Key points from your product docs:
+- [summarize relevant points]
+
+(Confirm alignment or note any adjustments)
+```
+
+If no product folder exists, skip this step.
+
+### Step 5: Surface Relevant Standards
+
+Read `agent-os/standards/index.yml` to identify relevant standards based on the feature being built.
+
+Use AskUserQuestion to confirm:
+
+```
+Based on what we're building, these standards may apply:
+
+1. **api/response-format** — API response envelope structure
+2. **api/error-handling** — Error codes and exception handling
+3. **database/migrations** — Migration patterns
+
+Should I include these in the spec? (yes / adjust: remove 3, add frontend/forms)
+```
+
+Read the confirmed standards files to include their content in the plan context.
+
+### Step 6: Generate Spec Folder Name
+
+Create a folder name using this format:
+```
+YYYY-MM-DD-HHMM-{feature-slug}/
+```
+
+Where:
+- Date/time is current timestamp
+- Feature slug is derived from the feature description (lowercase, hyphens, max 40 chars)
+
+Example: `2026-01-15-1430-user-comment-system/`
+
+**Note:** If `agent-os/specs/` doesn't exist, create it when saving the spec folder.
+
+### Step 7: Structure the Plan
+
+Now build the plan with **Task 1 always being "Save spec documentation"**.
+
+Present this structure to the user:
+
+```
+Here's the plan structure. Task 1 saves all our shaping work before implementation begins.
+
+---
+
+## Task 1: Save Spec Documentation
+
+Create `agent-os/specs/{folder-name}/` with:
+
+- **plan.md** — This full plan
+- **shape.md** — Shaping notes (scope, decisions, context from our conversation)
+- **standards.md** — Relevant standards that apply to this work
+- **references.md** — Pointers to reference implementations studied
+- **visuals/** — Any mockups or screenshots provided
+
+## Task 2: [First implementation task]
+
+[Description based on the feature]
+
+## Task 3: [Next task]
+
+...
+
+---
+
+Does this plan structure look right? I'll fill in the implementation tasks next.
+```
+
+### Step 8: Complete the Plan
+
+After Task 1 is confirmed, continue building out the remaining implementation tasks based on:
+- The feature scope from Step 1
+- Patterns from reference implementations (Step 3)
+- Constraints from standards (Step 5)
+
+Each task should be specific and actionable.
+
+### Step 9: Ready for Execution
+
+When the full plan is ready:
+
+```
+Plan complete. When you approve and execute:
+
+1. Task 1 will save all spec documentation first
+2. Then implementation tasks will proceed
+
+Ready to start? (approve / adjust)
+```
+
+## Output Structure
+
+The spec folder will contain:
+
+```
+agent-os/specs/{YYYY-MM-DD-HHMM-feature-slug}/
+├── plan.md           # The full plan
+├── shape.md          # Shaping decisions and context
+├── standards.md      # Which standards apply and key points
+├── references.md     # Pointers to similar code
+└── visuals/          # Mockups, screenshots (if any)
+```
+
+## shape.md Content
+
+The shape.md file should capture:
+
+```markdown
+# {Feature Name} — Shaping Notes
+
+## Scope
+
+[What we're building, from Step 1]
+
+## Decisions
+
+- [Key decisions made during shaping]
+- [Constraints or requirements noted]
+
+## Context
+
+- **Visuals:** [List of visuals provided, or "None"]
+- **References:** [Code references studied]
+- **Product alignment:** [Notes from product context, or "N/A"]
+
+## Standards Applied
+
+- api/response-format — [why it applies]
+- api/error-handling — [why it applies]
+```
+
+## standards.md Content
+
+Include the full content of each relevant standard:
+
+```markdown
+# Standards for {Feature Name}
+
+The following standards apply to this work.
+
+---
+
+## api/response-format
+
+[Full content of the standard file]
+
+---
+
+## api/error-handling
+
+[Full content of the standard file]
+```
+
+## references.md Content
+
+```markdown
+# References for {Feature Name}
+
+## Similar Implementations
+
+### {Reference 1 name}
+
+- **Location:** `src/features/comments/`
+- **Relevance:** [Why this is relevant]
+- **Key patterns:** [What to borrow from this]
+
+### {Reference 2 name}
+
+...
+```
+
+## Tips
+
+- **Keep shaping fast** — Don't over-document. Capture enough to start, refine as you build.
+- **Visuals are optional** — Not every feature needs mockups.
+- **Standards guide, not dictate** — They inform the plan but aren't always mandatory.
+- **Specs are discoverable** — Months later, someone can find this spec and understand what was built and why.

--- a/agent-os/product/mission.md
+++ b/agent-os/product/mission.md
@@ -1,0 +1,21 @@
+# Product Mission
+
+## Problem
+
+Code reviews lack depth and breadth. Most reviews focus on either the big picture or the details, rarely both. They tend to evaluate through a single lens (security, reliability, scalability) rather than multiple perspectives simultaneously. Reviews often fail to provide clear, actionable guidance on how to move forward.
+
+## Target Users
+
+- **CTOs and Tech Leaders** - Assess codebase maturity and technical debt across teams
+- **Engineering Teams** - Get structured, expert-level code reviews as part of day-to-day workflow
+
+## Solution
+
+A multi-perspective code review system that runs specialized subagents in parallel, each backed by industry frameworks:
+
+- **Multi-perspective parallel reviews** - 4 subagents per domain, each with framework-backed checklists (STRIDE, ROAD, C4, DAMA DMBOK)
+- **Portable prompt library** - LLM-agnostic prompts that work with Claude Code in the cloud or locally via Ollama with open-source models
+- **Actionable, structured output** - Severity-ranked findings with specific file locations and recommendations
+- **Summary reviews** - Provide next-best-actions for immediate priorities
+- **Detailed reviews** - Document all future work comprehensively
+- **Hygiene factors and maturity levels** - Reports highlight critical issues to address and aspirational targets to motivate teams

--- a/agent-os/product/roadmap.md
+++ b/agent-os/product/roadmap.md
@@ -1,0 +1,19 @@
+# Product Roadmap
+
+## Phase 1: MVP
+
+- **4 review domains** with parallel subagents:
+  - Architecture (`/review-arch`) - C4 zoom levels, DDD, Release It!, EIP
+  - SRE (`/review-sre`) - ROAD framework, SEEMS/FaCTOR failure analysis
+  - Security (`/review-security`) - STRIDE threat modeling
+  - Data (`/review-data`) - DAMA DMBOK, Data Mesh principles
+- **Summary reports** - Consolidated findings with severity-ranked action items
+- **Maturity scoring** - Hygiene factors (must-fix) and aspirational maturity targets
+
+## Phase 2: Post-Launch
+
+- **Product review domain** - Feature completeness, user journey, accessibility
+- **UX review domain** - Usability heuristics, consistency, responsiveness
+- **Local Ollama support** - Docker-based reviews with open-source models for air-gapped environments
+- **CI/CD integration** - Automated reviews triggered on releases (one per day), results published to the GitHub release
+- **Tracking** - Each release review collects previous release reports as inputs to create a chart tracking maturity over time.

--- a/agent-os/product/tech-stack.md
+++ b/agent-os/product/tech-stack.md
@@ -1,0 +1,19 @@
+# Tech Stack
+
+## Review Engine (Cloud)
+
+- **Claude Code CLI** - Primary review orchestrator
+- **Claude Code Skills** - Review commands (`/review-arch`, `/review-sre`, etc.)
+- **Claude Code Agents** - Specialized subagents per review pillar
+- **Markdown Prompts** - LLM-agnostic review checklists in `.claude/prompts/`
+
+## Review Engine (Local)
+
+- **Ollama** - Local LLM inference server
+- **Docker** - Containerized Ollama with pre-loaded models (DeepSeek R1)
+- **Python** - Ollama API client prototype (`python/code_review.py`)
+
+## Infrastructure
+
+- **Git/GitHub** - Version control and collaboration
+- **Docker Compose** - GPU-accelerated local inference setup

--- a/agent-os/standards/backend/api.md
+++ b/agent-os/standards/backend/api.md
@@ -1,0 +1,10 @@
+## API endpoint standards and conventions
+
+- **RESTful Design**: Follow REST principles with clear resource-based URLs and appropriate HTTP methods (GET, POST, PUT, PATCH, DELETE)
+- **Consistent Naming**: Use consistent, lowercase, hyphenated or underscored naming conventions for endpoints across the API
+- **Versioning**: Implement API versioning strategy (URL path or headers) to manage breaking changes without disrupting existing clients
+- **Plural Nouns**: Use plural nouns for resource endpoints (e.g., `/users`, `/products`) for consistency
+- **Nested Resources**: Limit nesting depth to 2-3 levels maximum to keep URLs readable and maintainable
+- **Query Parameters**: Use query parameters for filtering, sorting, pagination, and search rather than creating separate endpoints
+- **HTTP Status Codes**: Return appropriate, consistent HTTP status codes that accurately reflect the response (200, 201, 400, 404, 500, etc.)
+- **Rate Limiting Headers**: Include rate limit information in response headers to help clients manage their usage

--- a/agent-os/standards/backend/migrations.md
+++ b/agent-os/standards/backend/migrations.md
@@ -1,0 +1,9 @@
+## Database migration best practices
+
+- **Reversible Migrations**: Always implement rollback/down methods to enable safe migration reversals
+- **Small, Focused Changes**: Keep each migration focused on a single logical change for clarity and easier troubleshooting
+- **Zero-Downtime Deployments**: Consider deployment order and backwards compatibility for high-availability systems
+- **Separate Schema and Data**: Keep schema changes separate from data migrations for better rollback safety
+- **Index Management**: Create indexes on large tables carefully, using concurrent options when available to avoid locks
+- **Naming Conventions**: Use clear, descriptive names that indicate what the migration does
+- **Version Control**: Always commit migrations to version control and never modify existing migrations after deployment

--- a/agent-os/standards/backend/models.md
+++ b/agent-os/standards/backend/models.md
@@ -1,0 +1,10 @@
+## Database model best practices
+
+- **Clear Naming**: Use singular names for models and plural for tables following your framework's conventions
+- **Timestamps**: Include created and updated timestamps on all tables for auditing and debugging
+- **Data Integrity**: Use database constraints (NOT NULL, UNIQUE, foreign keys) to enforce data rules at the database level
+- **Appropriate Data Types**: Choose data types that match the data's purpose and size requirements
+- **Indexes on Foreign Keys**: Index foreign key columns and other frequently queried fields for performance
+- **Validation at Multiple Layers**: Implement validation at both model and database levels for defense in depth
+- **Relationship Clarity**: Define relationships clearly with appropriate cascade behaviors and naming conventions
+- **Avoid Over-Normalization**: Balance normalization with practical query performance needs

--- a/agent-os/standards/backend/queries.md
+++ b/agent-os/standards/backend/queries.md
@@ -1,0 +1,9 @@
+## Database query best practices
+
+- **Prevent SQL Injection**: Always use parameterized queries or ORM methods; never interpolate user input into SQL strings
+- **Avoid N+1 Queries**: Use eager loading or joins to fetch related data in a single query instead of multiple queries
+- **Select Only Needed Data**: Request only the columns you need rather than using SELECT * for better performance
+- **Index Strategic Columns**: Index columns used in WHERE, JOIN, and ORDER BY clauses for query optimization
+- **Use Transactions for Related Changes**: Wrap related database operations in transactions to maintain data consistency
+- **Set Query Timeouts**: Implement timeouts to prevent runaway queries from impacting system performance
+- **Cache Expensive Queries**: Cache results of complex or frequently-run queries when appropriate

--- a/agent-os/standards/frontend/accessibility.md
+++ b/agent-os/standards/frontend/accessibility.md
@@ -1,0 +1,10 @@
+## UI accessibility best practices
+
+- **Semantic HTML**: Use appropriate HTML elements (nav, main, button, etc.) that convey meaning to assistive technologies
+- **Keyboard Navigation**: Ensure all interactive elements are accessible via keyboard with visible focus indicators
+- **Color Contrast**: Maintain sufficient contrast ratios (4.5:1 for normal text) and don't rely solely on color to convey information
+- **Alternative Text**: Provide descriptive alt text for images and meaningful labels for all form inputs
+- **Screen Reader Testing**: Test and verify that all views are accessible on screen reading devices.
+- **ARIA When Needed**: Use ARIA attributes to enhance complex components when semantic HTML isn't sufficient
+- **Logical Heading Structure**: Use heading levels (h1-h6) in proper order to create a clear document outline
+- **Focus Management**: Manage focus appropriately in dynamic content, modals, and single-page applications

--- a/agent-os/standards/frontend/components.md
+++ b/agent-os/standards/frontend/components.md
@@ -1,0 +1,11 @@
+## UI component best practices
+
+- **Single Responsibility**: Each component should have one clear purpose and do it well
+- **Reusability**: Design components to be reused across different contexts with configurable props
+- **Composability**: Build complex UIs by combining smaller, simpler components rather than monolithic structures
+- **Clear Interface**: Define explicit, well-documented props with sensible defaults for ease of use
+- **Encapsulation**: Keep internal implementation details private and expose only necessary APIs
+- **Consistent Naming**: Use clear, descriptive names that indicate the component's purpose and follow team conventions
+- **State Management**: Keep state as local as possible; lift it up only when needed by multiple components
+- **Minimal Props**: Keep the number of props manageable; if a component needs many props, consider composition or splitting it
+- **Documentation**: Document component usage, props, and provide examples for easier adoption by team members

--- a/agent-os/standards/frontend/css.md
+++ b/agent-os/standards/frontend/css.md
@@ -1,0 +1,7 @@
+## CSS best practices
+
+- **Consistent Methodology**: Apply and stick to the project's consistent CSS methodology (Tailwind, BEM, utility classes, CSS modules, etc.) across the entire project
+- **Avoid Overriding Framework Styles**: Work with your framework's patterns rather than fighting against them with excessive overrides
+- **Maintain Design System**: Establish and document design tokens (colors, spacing, typography) for consistency
+- **Minimize Custom CSS**: Leverage framework utilities and components to reduce custom CSS maintenance burden
+- **Performance Considerations**: Optimize for production with CSS purging/tree-shaking to remove unused styles

--- a/agent-os/standards/frontend/responsive.md
+++ b/agent-os/standards/frontend/responsive.md
@@ -1,0 +1,11 @@
+## Responsive design best practices
+
+- **Mobile-First Development**: Start with mobile layout and progressively enhance for larger screens
+- **Standard Breakpoints**: Consistently use standard breakpoints across the application (e.g., mobile, tablet, desktop)
+- **Fluid Layouts**: Use percentage-based widths and flexible containers that adapt to screen size
+- **Relative Units**: Prefer rem/em units over fixed pixels for better scalability and accessibility
+- **Test Across Devices**: Test and verify UI changes across multiple screen sizes from mobile to tablet to desktop screen sizes and ensure a balanced, user-friendly viewing and reading experience on all
+- **Touch-Friendly Design**: Ensure tap targets are appropriately sized (minimum 44x44px) for mobile users
+- **Performance on Mobile**: Optimize images and assets for mobile network conditions and smaller screens
+- **Readable Typography**: Maintain readable font sizes across all breakpoints without requiring zoom
+- **Content Priority**: Show the most important content first on smaller screens through thoughtful layout decisions

--- a/agent-os/standards/global/coding-style.md
+++ b/agent-os/standards/global/coding-style.md
@@ -1,0 +1,10 @@
+## Coding style best practices
+
+- **Consistent Naming Conventions**: Establish and follow naming conventions for variables, functions, classes, and files across the codebase
+- **Automated Formatting**: Maintain consistent code style (indenting, line breaks, etc.)
+- **Meaningful Names**: Choose descriptive names that reveal intent; avoid abbreviations and single-letter variables except in narrow contexts
+- **Small, Focused Functions**: Keep functions small and focused on a single task for better readability and testability
+- **Consistent Indentation**: Use consistent indentation (spaces or tabs) and configure your editor/linter to enforce it
+- **Remove Dead Code**: Delete unused code, commented-out blocks, and imports rather than leaving them as clutter
+- **Backward compatibility only when required:** Unless specifically instructed otherwise, assume you do not need to write additional code logic to handle backward compatibility.
+- **DRY Principle**: Avoid duplication by extracting common logic into reusable functions or modules

--- a/agent-os/standards/global/commenting.md
+++ b/agent-os/standards/global/commenting.md
@@ -1,0 +1,5 @@
+## Code commenting best practices
+
+- **Self-Documenting Code**: Write code that explains itself through clear structure and naming
+- **Minimal, helpful comments**: Add concise, minimal comments to explain large sections of code logic.
+- **Don't comment changes or fixes**: Do not leave code comments that speak to recent or temporary changes or fixes. Comments should be evergreen informational texts that are relevant far into the future.

--- a/agent-os/standards/global/conventions.md
+++ b/agent-os/standards/global/conventions.md
@@ -1,0 +1,11 @@
+## General development conventions
+
+- **Consistent Project Structure**: Organize files and directories in a predictable, logical structure that team members can navigate easily
+- **Clear Documentation**: Maintain up-to-date README files with setup instructions, architecture overview, and contribution guidelines
+- **Version Control Best Practices**: Use clear commit messages, feature branches, and meaningful pull/merge requests with descriptions
+- **Environment Configuration**: Use environment variables for configuration; never commit secrets or API keys to version control
+- **Dependency Management**: Keep dependencies up-to-date and minimal; document why major dependencies are used
+- **Code Review Process**: Establish a consistent code review process with clear expectations for reviewers and authors
+- **Testing Requirements**: Define what level of testing is required before merging (unit tests, integration tests, etc.)
+- **Feature Flags**: Use feature flags for incomplete features rather than long-lived feature branches
+- **Changelog Maintenance**: Keep a changelog or release notes to track significant changes and improvements

--- a/agent-os/standards/global/error-handling.md
+++ b/agent-os/standards/global/error-handling.md
@@ -1,0 +1,9 @@
+## Error handling best practices
+
+- **User-Friendly Messages**: Provide clear, actionable error messages to users without exposing technical details or security information
+- **Fail Fast and Explicitly**: Validate input and check preconditions early; fail with clear error messages rather than allowing invalid state
+- **Specific Exception Types**: Use specific exception/error types rather than generic ones to enable targeted handling
+- **Centralized Error Handling**: Handle errors at appropriate boundaries (controllers, API layers) rather than scattering try-catch blocks everywhere
+- **Graceful Degradation**: Design systems to degrade gracefully when non-critical services fail rather than breaking entirely
+- **Retry Strategies**: Implement exponential backoff for transient failures in external service calls
+- **Clean Up Resources**: Always clean up resources (file handles, connections) in finally blocks or equivalent mechanisms

--- a/agent-os/standards/global/tech-stack.md
+++ b/agent-os/standards/global/tech-stack.md
@@ -1,0 +1,31 @@
+## Tech stack
+
+Define your technical stack below. This serves as a reference for all team members and helps maintain consistency across the project.
+
+### Framework & Runtime
+- **Application Framework:** Next.js, Express
+- **Language/Runtime:** Node.js
+- **Package Manager:** npm, yarn
+
+### Frontend
+- **JavaScript Framework:** React
+- **CSS Framework:** Tailwind CSS
+- **UI Components:** [e.g., shadcn/ui, Material UI, custom library]
+
+### Database & Storage
+- **Database:** PostgreSQL
+- **ORM/Query Builder:** None
+- **Caching:** None
+
+### Testing & Quality
+- **Test Framework:** Jest
+- **Linting/Formatting:** ESLint
+
+### Deployment & Infrastructure
+- **Hosting:** Vercel
+- **CI/CD:** GitHub Actions, Vercel
+
+### Third-Party Services
+- **Authentication:** None
+- **Email:** None
+- **Monitoring:** None

--- a/agent-os/standards/global/validation.md
+++ b/agent-os/standards/global/validation.md
@@ -1,0 +1,11 @@
+## Validation best practices
+
+- **Validate on Server Side**: Always validate on the server; never trust client-side validation alone for security or data integrity
+- **Client-Side for UX**: Use client-side validation to provide immediate user feedback, but duplicate checks server-side
+- **Fail Early**: Validate input as early as possible and reject invalid data before processing
+- **Specific Error Messages**: Provide clear, field-specific error messages that help users correct their input
+- **Allowlists Over Blocklists**: When possible, define what is allowed rather than trying to block everything that's not
+- **Type and Format Validation**: Check data types, formats, ranges, and required fields systematically
+- **Sanitize Input**: Sanitize user input to prevent injection attacks (SQL, XSS, command injection)
+- **Business Rule Validation**: Validate business rules (e.g., sufficient balance, valid dates) at the appropriate application layer
+- **Consistent Validation**: Apply validation consistently across all entry points (web forms, API endpoints, background jobs)

--- a/agent-os/standards/index.yml
+++ b/agent-os/standards/index.yml
@@ -1,0 +1,40 @@
+# Agent OS Standards Index
+
+backend:
+  api:
+    description: Needs description - run /index-standards
+  migrations:
+    description: Needs description - run /index-standards
+  models:
+    description: Needs description - run /index-standards
+  queries:
+    description: Needs description - run /index-standards
+
+frontend:
+  accessibility:
+    description: Needs description - run /index-standards
+  components:
+    description: Needs description - run /index-standards
+  css:
+    description: Needs description - run /index-standards
+  responsive:
+    description: Needs description - run /index-standards
+
+global:
+  coding-style:
+    description: Needs description - run /index-standards
+  commenting:
+    description: Needs description - run /index-standards
+  conventions:
+    description: Needs description - run /index-standards
+  error-handling:
+    description: Needs description - run /index-standards
+  tech-stack:
+    description: Needs description - run /index-standards
+  validation:
+    description: Needs description - run /index-standards
+
+testing:
+  test-writing:
+    description: Needs description - run /index-standards
+

--- a/agent-os/standards/testing/test-writing.md
+++ b/agent-os/standards/testing/test-writing.md
@@ -1,0 +1,9 @@
+## Test coverage best practices
+
+- **Write Minimal Tests During Development**: Do NOT write tests for every change or intermediate step. Focus on completing the feature implementation first, then add strategic tests only at logical completion points
+- **Test Only Core User Flows**: Write tests exclusively for critical paths and primary user workflows. Skip writing tests for non-critical utilities and secondary workflows until if/when you're instructed to do so.
+- **Defer Edge Case Testing**: Do NOT test edge cases, error states, or validation logic unless they are business-critical. These can be addressed in dedicated testing phases, not during feature development.
+- **Test Behavior, Not Implementation**: Focus tests on what the code does, not how it does it, to reduce brittleness
+- **Clear Test Names**: Use descriptive names that explain what's being tested and the expected outcome
+- **Mock External Dependencies**: Isolate units by mocking databases, APIs, file systems, and other external services
+- **Fast Execution**: Keep unit tests fast (milliseconds) so developers run them frequently during development

--- a/readme.md
+++ b/readme.md
@@ -1,71 +1,166 @@
-Run the model in a container
-https://blog.xeynergy.com/running-deepseek-r1-locally-with-ollama-and-docker-9b2b7d05607a
+# Code Review LLM
+
+A sophisticated, multi-perspective code review system that helps CTOs and technology leaders understand the maturity of their codebase. Run reviews with Claude Code in the cloud, or locally in Docker using Ollama with smaller open-source LLMs.
+
+## Review Domains
+
+Each domain runs 4 specialized subagents in parallel, producing a consolidated report with prioritized findings.
+
+| Domain | Command | Framework | What It Evaluates |
+|--------|---------|-----------|-------------------|
+| **Architecture** | `/review-arch` | C4 zoom levels (Code, Service, System, Landscape) | SOLID, DDD, Clean Architecture, Release It! stability patterns, EIP, ADR compliance |
+| **SRE** | `/review-sre` | ROAD (Response, Observability, Availability, Delivery) | SEEMS/FaCTOR failure analysis, SLOs, circuit breakers, deployment safety |
+| **Security** | `/review-security` | STRIDE threat modeling | Authentication, data protection, input validation, audit trails, DoS resilience |
+| **Data** | `/review-data` | DAMA DMBOK + Data Mesh | Schema design, data contracts, quality SLOs, PII governance, lineage |
+
+### Coming Soon
+
+| Domain | Focus |
+|--------|-------|
+| **Product** | Feature completeness, user journey, accessibility |
+| **UX** | Usability heuristics, consistency, responsiveness |
+
+## How It Works
 
 ```
-docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
-docker exec -it ollama /bin/bash
-ollama pull deepseek-r1:1.5b
-ollama run deepseek-r1:1.5b
+/review-arch src/                    # Review architecture of src/
+/review-sre src/api/                 # SRE review of the API layer
+/review-security .                   # Security review of entire project
+/review-data src/pipelines/          # Data review of pipeline code
 ```
 
-hit the api like this
+Each review command:
 
-```
-curl http://localhost:11434/api/chat -d '{
-  "model": "deepseek-r1:1.5b",
-  "messages": [{ "role": "user", "content": "Solve: 25 * 25" }],
-  "stream": false
-}'
-```
+1. Spawns 4 specialized subagents in parallel (one per pillar)
+2. Each agent reads shared prompt templates from `.claude/prompts/`
+3. Agents independently analyze the code against their checklist
+4. Results are deduplicated, prioritized by severity, and consolidated into a single report
 
+### Output
 
+Reports include:
 
-https://www.datacamp.com/tutorial/deepseek-r1-ollama
+- Executive summary with finding counts by severity (HIGH / MEDIUM / LOW)
+- Detailed findings per pillar with file locations and recommendations
+- Consolidated action items table sorted by priority
+- Positive patterns observed
 
+## Running Reviews
 
-# New pre built Deepseek Docker image 
+### With Claude Code (Cloud)
 
-Build the image. 
-Note: this will pull ~5GB (1.5GB for Ollama docker image, then 3.5GB for deepseek)
+Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and run from the target project directory:
+
 ```bash
-docker build -f deepseek-r1.dockerfile -t ollama-deepseek:1.0 
+# Copy the .claude/ directory into your project
+cp -r .claude/ /path/to/your/project/.claude/
+
+# Run a review
+claude "/review-arch src/"
 ```
 
-Run the container
+### With Docker + Ollama (Local)
+
+For air-gapped or cost-sensitive environments, run reviews locally using Ollama with open-source models. The shared prompt templates in `.claude/prompts/` are designed to work with any LLM.
+
+#### Quick Start
+
+Build and run the Ollama container with DeepSeek R1:
 
 ```bash
+# Build (pulls ~5GB: 1.5GB Ollama image + model weights)
+docker build -f .devcontainer/deepseek-r1.014b.dockerfile -t ollama-deepseek:1.0 .
+
+# Run
 docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama-deepseek ollama-deepseek:1.0
-```
 
-Test the end point is accepting requests, and the model is running.
-
-```bash
+# Verify
 curl http://localhost:11434/api/chat -d '{
-  "model": "deepseek-r1:1.5b",
-  "messages": [{ "role": "user", "content": "What LLM are you, and what version of that LLM model?" }],
+  "model": "deepseek-r1:14b",
+  "messages": [{ "role": "user", "content": "What LLM are you?" }],
   "stream": false
 }'
 ```
 
-Test it can do something basic (multiply 25 by 25).
+#### Available Models
+
+| Dockerfile | Model | Size | Use Case |
+|-----------|-------|------|----------|
+| `deepseek-r1.001.5b` | DeepSeek R1 1.5B | ~1.5GB | Quick smoke tests |
+| `deepseek-r1.014b` | DeepSeek R1 14B | ~9GB | Good balance of quality and speed |
+| `deepseek-r1.032b` | DeepSeek R1 32B | ~20GB | Higher quality reviews |
+| `deepseek-r1.070b` | DeepSeek R1 70B | ~40GB | Best local quality |
+| `deepseek-r1.671b` | DeepSeek R1 671B | ~400GB | Full model (requires significant hardware) |
+
+#### Docker Compose (GPU)
+
+For GPU-accelerated inference:
 
 ```bash
-curl http://localhost:11434/api/chat -d '{
-  "model": "deepseek-r1:1.5b",
-  "messages": [{ "role": "user", "content": "Solve: 25 * 25" }],
-  "stream": false
-}'
+cd .devcontainer
+docker compose up -d
 ```
 
-When you are done, you can stop the container with 
+#### Cleanup
 
 ```bash
 docker container stop ollama-deepseek
+docker container rm ollama-deepseek    # Remove to reclaim disk
 ```
 
-Note that the container is just stopped, which means you can restart it keeping the context.
-If you want to remove the container, to reclaim disk, or to re-run a new version with the same container name
+## Project Structure
 
-``bash
-docker container stop ollama-deepseek
 ```
+.claude/
+├── prompts/                    # Shared review checklists (LLM-agnostic)
+│   ├── architecture/
+│   │   ├── _base.md            # C4 zoom levels, glossary, severity definitions
+│   │   ├── code.md             # SOLID, DDD tactical, testability, naming
+│   │   ├── service.md          # Bounded contexts, layering, deployability
+│   │   ├── system.md           # Stability patterns, API contracts, coupling
+│   │   └── landscape.md        # EIP, context maps, ADRs, tech-spec traceability
+│   ├── sre/
+│   │   ├── _base.md            # SEEMS/FaCTOR framework, terminology
+│   │   ├── response.md         # Incident handling, runbook readiness
+│   │   ├── observability.md    # Logging, metrics, tracing, SLIs
+│   │   ├── availability.md     # SLOs, circuit breakers, resilience
+│   │   └── delivery.md         # Deployment safety, rollback, feature flags
+│   ├── security/
+│   │   ├── _base.md            # STRIDE categories, DREAD-lite scoring
+│   │   ├── authn-authz.md      # Authentication, authorization, sessions
+│   │   ├── data-protection.md  # Encryption, secrets, data integrity
+│   │   ├── input-validation.md # SQL injection, XSS, command injection
+│   │   └── audit-resilience.md # Audit trails, rate limiting, DoS
+│   └── data/
+│       ├── _base.md            # Data quality dimensions, terminology
+│       ├── architecture.md     # Schema design, interoperability, contracts
+│       ├── engineering.md      # Logic verification, performance, error handling
+│       ├── quality.md          # Freshness SLOs, accuracy, observability
+│       └── governance.md       # PII classification, retention, lineage
+├── agents/                     # Subagent definitions (Claude Code)
+│   ├── arch-{code,service,system,landscape}.md
+│   ├── sre-{response,observability,availability,delivery}.md
+│   ├── security-{authn-authz,data-protection,input-validation,audit-resilience}.md
+│   └── data-{architecture,engineering,quality,governance}.md
+└── skills/                     # Review orchestrators (Claude Code)
+    ├── review-arch/SKILL.md
+    ├── review-sre/SKILL.md
+    ├── review-security/SKILL.md
+    └── review-data/SKILL.md
+
+.devcontainer/                  # Docker + Ollama local setup
+├── docker-compose.yml
+└── deepseek-r1.*.dockerfile
+
+python/
+└── code_review.py              # Ollama API client (prototype)
+```
+
+## Frameworks and Sources
+
+| Domain | Primary Sources |
+|--------|----------------|
+| Architecture | Domain-Driven Design (Evans), Modern Software Engineering (Farley), Release It! (Nygard), Enterprise Integration Patterns (Hohpe & Woolf), C4 Model (Brown) |
+| SRE | SEEMS/FaCTOR failure analysis, ROAD framework, Google SRE Book |
+| Security | STRIDE (Microsoft), DREAD-lite risk scoring, OWASP Top 10 |
+| Data | DAMA DMBOK, Data Mesh (Dehghani), Data Governance for Everyone |


### PR DESCRIPTION
## Summary

- Adds Agent OS slash commands for project management workflows: discover/index/inject standards, plan product, and shape spec
- Creates standards templates covering backend, frontend, global, and testing conventions
- Establishes product documentation (mission, roadmap, tech stack) for the code review system
- Rewrites README with comprehensive project documentation

**Stacked on:** #7

## Test plan

- [ ] Verify `/agent-os:discover-standards` command runs and prompts for focus area
- [ ] Verify `/agent-os:plan-product` command runs and creates product docs
- [ ] Verify `/agent-os:inject-standards` command injects standards into CLAUDE.md
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)