### PR TITLE
Fix SRE and Security prompt issues

### DIFF
--- a/.claude/prompts/security/input-validation.md
+++ b/.claude/prompts/security/input-validation.md
@@ -47,10 +47,14 @@ Injection attacks remain the most dangerous vulnerability class. SQL injection, 
 
 ### Deserialization
 
-- [ ] Is untrusted data deserialized?
-- [ ] Are safe deserialization methods used?
-- [ ] Is pickle/marshal avoided for untrusted data?
-- [ ] Are type constraints enforced?
+**Always unsafe** (arbitrary code execution by design):
+- [ ] Is `pickle` / `marshal` avoided for untrusted data? These execute arbitrary code on load — no safe mode exists.
+
+**Loader-dependent** (safe if configured correctly):
+- [ ] Is `yaml.safe_load()` used instead of `yaml.load()`?
+- [ ] Is XML parsed with external entity resolution disabled?
+- [ ] Are JSON parsers used with size/depth limits?
+- [ ] Are type constraints enforced on deserialized objects?
 
 ### Template Injection
 

--- a/.claude/prompts/sre/availability.md
+++ b/.claude/prompts/sre/availability.md
@@ -49,7 +49,7 @@ A 99.9% SLO means you have 8.7 hours of downtime budget per year. Every code cha
 | **Shared fate** | If this fails, what else fails? Is the blast radius acceptable? Are there shared connection pools, caches, or queues that create coupling? |
 | **Excessive load** | What happens at 10x traffic? Is there fan-out that amplifies load? Are there retry storms waiting to happen? |
 | **Excessive latency** | What's the worst-case latency? Are there unbounded operations (full table scans, unlimited pagination)? |
-| **SPOF** | What's the redundancy story? Can this run in multiple regions/zones? What state needs to be replicated? |
+| **Single points of failure** | What's the redundancy story? Can this run in multiple regions/zones? What state needs to be replicated? |
 
 ## FaCTOR Deep Dive for Availability
 


### PR DESCRIPTION
## Summary

- **SRE availability.md**: Replace "SPOF" acronym with "Single points of failure" to match the SEEMS framework definition in `_base.md`
- **Security input-validation.md**: Separate deserialization risks by severity — `pickle`/`marshal` are always unsafe (arbitrary code execution), while YAML/XML/JSON are loader-dependent and safe when configured correctly

## Test plan

- [ ] Verify SEEMS table in availability.md uses consistent terminology with _base.md
- [ ] Verify deserialization checklist distinguishes always-unsafe from loader-dependent formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)