### PR TITLE
Add cascading maturity model to all review domains

### DIFF
--- a/.claude/prompts/architecture/_base.md
+++ b/.claude/prompts/architecture/_base.md
@@ -102,13 +102,45 @@ These apply at all zoom levels:
 
 ---
 
+## Maturity Model
+
+Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+
+| Level | Criteria for Architecture |
+|-------|--------------------------|
+| **Hygiene** | No circular dependencies between modules. No shared mutable state across boundaries. No god classes or modules with unbounded responsibility. |
+| **Level 1 — Foundations** | Clear module boundaries with explicit public APIs. SRP followed at class/module level. Dependencies flow inward (infrastructure depends on domain, not vice versa). Architecture diagrams published and current. |
+| **Level 2 — Operational Maturity** | DDD tactical patterns applied (aggregates, value objects, domain events). Bounded contexts explicit with defined integration contracts. ADRs document key architectural decisions. Stability patterns (circuit breakers, bulkheads) applied at integration points. |
+| **Level 3 — Excellence** | Fitness functions validate architectural characteristics automatically. Context maps document cross-system relationships. EIP patterns govern inter-system messaging. Evolutionary architecture — changes are safe, incremental, and reversible. |
+
+### Tagging Rules
+
+For each finding, add a `Maturity` column to your output table:
+- `HYG` — Hygiene violation (baseline safety failure)
+- `L1` — Level 1 criteria gap
+- `L2` — Level 2 criteria gap
+- `L3` — Level 3 criteria gap
+
+### Criteria Assessment
+
+After your findings table, add a **Maturity Assessment** section:
+
+For each criterion at each level, state:
+- ✅ **Met** — Evidence found in code (cite location)
+- ❌ **Not met** — What's missing (cite what should exist)
+- ⚠️ **Partially met** — Some evidence, gaps remain
+
+Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+
+---
+
 ## Output Format
 
 Present findings as:
 
-| Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | ---------- | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Code/Service/System/Landscape | file:line | What's wrong | How to fix |
+| Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+| -------- | -------- | ---------- | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Code/Service/System/Landscape | file:line | What's wrong | How to fix |
 
 Prioritize HIGH severity items first. Be specific and actionable.
 

--- a/.claude/prompts/data/_base.md
+++ b/.claude/prompts/data/_base.md
@@ -77,13 +77,47 @@ This review framework synthesizes principles from:
 
 ---
 
+## Maturity Model
+
+Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+
+| Level | Criteria for Data |
+|-------|------------------|
+| **Hygiene** | No missing PII masking in outputs or logs. No breaking schema changes without versioning. No silent data loss (dropped records without error). No unhandled nulls in joins or aggregations. |
+| **Level 1 — Foundations** | Schema documented with field descriptions. Ownership defined for each data asset. Basic data validation (type checks, not-null constraints, referential integrity). Idempotent processing for all pipelines. |
+| **Level 2 — Operational Maturity** | Freshness SLOs defined and monitored. Data contracts between producers and consumers. Lineage tracked from source to consumption. Quality monitoring with automated anomaly detection. Reconciliation between source and target. |
+| **Level 3 — Excellence** | Bitemporality for audit-critical data. Self-serve discovery catalog. Automated reconciliation with alerting. Data mesh patterns — domain-owned data products with interoperability standards. |
+
+### Tagging Rules
+
+For each finding, add a `Maturity` column to your output table:
+
+- `HYG` — Hygiene violation (baseline safety failure)
+- `L1` — Level 1 criteria gap
+- `L2` — Level 2 criteria gap
+- `L3` — Level 3 criteria gap
+
+### Criteria Assessment
+
+After your findings table, add a **Maturity Assessment** section:
+
+For each criterion at each level, state:
+
+- ✅ **Met** — Evidence found in code (cite location)
+- ❌ **Not met** — What's missing (cite what should exist)
+- ⚠️ **Partially met** — Some evidence, gaps remain
+
+Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+
+---
+
 ## Output Format
 
 Present findings as:
 
-| Severity | Pillar | Location | Finding | Recommendation |
-| -------- | ------ | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Arch/Eng/Quality/Gov | file:line | What's wrong | How to fix |
+| Severity | Maturity | Pillar | Location | Finding | Recommendation |
+| -------- | -------- | ------ | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Arch/Eng/Quality/Gov | file:line | What's wrong | How to fix |
 
 Prioritize HIGH severity items first. Be specific and actionable.
 

--- a/.claude/prompts/security/_base.md
+++ b/.claude/prompts/security/_base.md
@@ -74,12 +74,46 @@ A valid security finding must have:
 | **MEDIUM** | Requires conditions, significant impact | IDOR needing valid session, XSS in admin panel |
 | **LOW** | Limited impact, defense-in-depth | Information disclosure in error messages |
 
+## Maturity Model
+
+Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+
+| Level | Criteria for Security |
+|-------|----------------------|
+| **Hygiene** | No SQL injection or command injection vectors. No hardcoded secrets or credentials in source. Authentication enforced on all protected routes. No path traversal vulnerabilities. |
+| **Level 1 — Foundations** | Auth/authz model exists and is consistently applied. Input validation on all external entry points. Secrets managed via vault or environment (not code). Session management follows best practices (expiry, rotation). |
+| **Level 2 — Operational Maturity** | STRIDE threat model coverage across all components. Audit trails for security-relevant actions. Rate limiting on authentication and public endpoints. Least-privilege defaults for all roles. Threat modelling documented per service. |
+| **Level 3 — Excellence** | Automated security testing in CI pipeline (SAST/DAST). Crypto-agility — encryption algorithms configurable, not hardcoded. Security chaos testing (fault injection for auth failures). Dependency vulnerability scanning automated. |
+
+### Tagging Rules
+
+For each finding, add a `Maturity` column to your output table:
+
+- `HYG` — Hygiene violation (baseline safety failure)
+- `L1` — Level 1 criteria gap
+- `L2` — Level 2 criteria gap
+- `L3` — Level 3 criteria gap
+
+### Criteria Assessment
+
+After your findings table, add a **Maturity Assessment** section:
+
+For each criterion at each level, state:
+
+- ✅ **Met** — Evidence found in code (cite location)
+- ❌ **Not met** — What's missing (cite what should exist)
+- ⚠️ **Partially met** — Some evidence, gaps remain
+
+Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+
+---
+
 ## Output Format
 
 Present findings as:
 
-| Severity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
-| -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
-| HIGH/MED/LOW | HIGH/MED | S/T/R/I/D/E | file:line | What's vulnerable | How to exploit | How to fix |
+| Severity | Maturity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
+| -------- | -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | HIGH/MED | S/T/R/I/D/E | file:line | What's vulnerable | How to exploit | How to fix |
 
 Prioritize HIGH severity + HIGH confidence items first. Be specific and actionable.

--- a/.claude/prompts/sre/_base.md
+++ b/.claude/prompts/sre/_base.md
@@ -39,12 +39,46 @@ Use FaCTOR to verify the code preserves these resilience properties:
 - **MEDIUM**: Operational risk that should be addressed. May require follow-up ticket.
 - **LOW**: Minor improvement opportunity. Nice to have.
 
+## Maturity Model
+
+Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+
+| Level | Criteria for SRE |
+|-------|-----------------|
+| **Hygiene** | No unbounded retries. No missing timeouts on external calls. No silent failure swallowing (empty catch blocks, ignored errors). No unvalidated configuration. |
+| **Level 1 — Foundations** | Health checks present and meaningful. Structured logging with correlation IDs. Basic alerting on error rates. Error handling at service boundaries with clear error propagation. |
+| **Level 2 — Operational Maturity** | SLOs defined and measurable. Circuit breakers on external dependencies. Graceful degradation paths documented. Runbook references in alert definitions. Resilience modelling applied (SEEMS/FaCTOR analysis documented). |
+| **Level 3 — Excellence** | Error budgets tracked and driving decisions. Chaos testing evidence (failure injection, game days). Zero-downtime deployment pipeline. Capacity planning with load shedding and backpressure validated under stress. |
+
+### Tagging Rules
+
+For each finding, add a `Maturity` column to your output table:
+
+- `HYG` — Hygiene violation (baseline safety failure)
+- `L1` — Level 1 criteria gap
+- `L2` — Level 2 criteria gap
+- `L3` — Level 3 criteria gap
+
+### Criteria Assessment
+
+After your findings table, add a **Maturity Assessment** section:
+
+For each criterion at each level, state:
+
+- ✅ **Met** — Evidence found in code (cite location)
+- ❌ **Not met** — What's missing (cite what should exist)
+- ⚠️ **Partially met** — Some evidence, gaps remain
+
+Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+
+---
+
 ### Output Format
 
 Present findings as:
 
-| Severity | Category | Location | Finding | Recommendation |
-|----------|----------|----------|---------|----------------|
-| HIGH/MED/LOW | SEEMS or FaCTOR category | file:line | What's wrong | How to fix it |
+| Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|---------|----------------|
+| HIGH/MED/LOW | HYG/L1/L2/L3 | SEEMS or FaCTOR category | file:line | What's wrong | How to fix it |
 
 Prioritize HIGH severity items first. Be specific about locations and actionable in recommendations.

--- a/.claude/skills/review-arch/SKILL.md
+++ b/.claude/skills/review-arch/SKILL.md
@@ -59,53 +59,61 @@ Each agent should:
 After all agents complete:
 
 1. **Collect findings** from all 4 zoom levels
-2. **Deduplicate** - Some issues may be flagged by multiple levels
-3. **Prioritize** - Sort by severity (HIGH → MEDIUM → LOW)
-4. **Summarize** - Provide executive summary
+2. **Deduplicate** — Some issues may be flagged by multiple levels
+3. **Aggregate maturity assessments** — Merge criteria assessments from all subagents into one maturity view
+4. **Determine maturity status per level:**
+   - All criteria ✅ → `pass` (✅)
+   - Mix of ✅ and ❌ → `partial` (⚠️)
+   - All criteria ❌ → `fail` (❌)
+   - Previous level not passed → `locked` (🔒)
+5. **Prioritize** findings by maturity level (HYG first), then severity (HIGH → LOW)
 
 ## Output Format
 
-### Executive Summary
+```markdown
+# Architecture Review — Maturity Assessment
 
-Brief overview of the review:
+## Maturity Status
 
-- Files reviewed
-- Total findings by severity
-- Top concerns across zoom levels
-- Which zoom levels are applicable for this project
+| Level | Status | Summary |
+|-------|--------|---------|
+| Hygiene | ✅/⚠️/❌ | [one-line summary] |
+| Level 1 — Foundations | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 2 — Operational Maturity | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 3 — Excellence | ✅/⚠️/❌/🔒 | [one-line summary] |
 
-### Findings by Zoom Level
+**Immediate Action:** [Top hygiene failure if hygiene not passed, else top action from next achievable level]
 
-#### Code (Module Structure)
+---
 
-[Findings from arch-code agent]
+## Hygiene
 
-#### Service (Deployable Design)
+[If any failures: list them with severity, zoom level, location, finding, recommendation]
+[If all pass: ✅ All hygiene criteria met]
 
-[Findings from arch-service agent]
+## [Next Achievable Level] — Detailed Assessment
 
-#### System (Service Interactions)
+For each criterion:
+- ✅ **[Criterion]** — Evidence: `file:line` description
+- ❌ **[Criterion]** — Missing: what should exist
+- ⚠️ **[Criterion]** — Partial: what's there and what's missing
 
-[Findings from arch-system agent]
+## Higher Levels — Preview
 
-#### Landscape (Ecosystem)
+> **Level [N+1]**: [Brief list of criteria — not yet assessed in detail]
+> **Level [N+2]**: [Brief list of criteria]
 
-[Findings from arch-landscape agent]
+---
 
-### Consolidated Action Items
+## Detailed Findings
 
-| Priority | Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | -------- | ---------- | -------- | ------- | -------------- |
-| 1 | HIGH | ... | ... | ... | ... |
+| Priority | Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+|----------|----------|----------|------------|----------|---------|----------------|
 
-### What's Good
+## What's Good
 
-Note positive architectural patterns observed:
-
-- Clean separation of concerns
-- Well-defined bounded contexts
-- Proper use of stability patterns
-- Good documentation and ADRs
+[Positive architectural patterns observed]
+```
 
 ## Relationship to Other Reviews
 

--- a/.claude/skills/review-data/SKILL.md
+++ b/.claude/skills/review-data/SKILL.md
@@ -71,52 +71,61 @@ Each agent should:
 After all agents complete:
 
 1. **Collect findings** from all 4 pillars
-2. **Deduplicate** - Some issues may be flagged by multiple reviewers
-3. **Prioritize** - Sort by severity (HIGH → MEDIUM → LOW)
-4. **Summarize** - Provide executive summary
+2. **Deduplicate** — Some issues may be flagged by multiple reviewers
+3. **Aggregate maturity assessments** — Merge criteria assessments from all subagents into one maturity view
+4. **Determine maturity status per level:**
+   - All criteria ✅ → `pass` (✅)
+   - Mix of ✅ and ❌ → `partial` (⚠️)
+   - All criteria ❌ → `fail` (❌)
+   - Previous level not passed → `locked` (🔒)
+5. **Prioritize** findings by maturity level (HYG first), then severity (HIGH → LOW)
 
 ## Output Format
 
-### Executive Summary
+```markdown
+# Data Review — Maturity Assessment
 
-Brief overview of the review:
+## Maturity Status
 
-- Files reviewed
-- Total findings by severity
-- Top concerns across pillars
+| Level | Status | Summary |
+|-------|--------|---------|
+| Hygiene | ✅/⚠️/❌ | [one-line summary] |
+| Level 1 — Foundations | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 2 — Operational Maturity | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 3 — Excellence | ✅/⚠️/❌/🔒 | [one-line summary] |
 
-### Findings by Pillar
+**Immediate Action:** [Top hygiene failure if hygiene not passed, else top action from next achievable level]
 
-#### Architecture (Schema & Design)
+---
 
-[Findings from data-architecture agent]
+## Hygiene
 
-#### Engineering (Logic & Code)
+[If any failures: list them with severity, pillar, location, finding, recommendation]
+[If all pass: ✅ All hygiene criteria met]
 
-[Findings from data-engineering agent]
+## [Next Achievable Level] — Detailed Assessment
 
-#### Quality (Trust & Timeliness)
+For each criterion:
+- ✅ **[Criterion]** — Evidence: `file:line` description
+- ❌ **[Criterion]** — Missing: what should exist
+- ⚠️ **[Criterion]** — Partial: what's there and what's missing
 
-[Findings from data-quality agent]
+## Higher Levels — Preview
 
-#### Governance (Compliance & Lifecycle)
+> **Level [N+1]**: [Brief list of criteria — not yet assessed in detail]
+> **Level [N+2]**: [Brief list of criteria]
 
-[Findings from data-governance agent]
+---
 
-### Consolidated Action Items
+## Detailed Findings
 
-| Priority | Severity | Pillar | Location | Finding | Recommendation |
-| -------- | -------- | ------ | -------- | ------- | -------------- |
-| 1 | HIGH | ... | ... | ... | ... |
+| Priority | Severity | Maturity | Pillar | Location | Finding | Recommendation |
+|----------|----------|----------|--------|----------|---------|----------------|
 
-### What's Good
+## What's Good
 
-Note positive patterns observed:
-
-- Well-designed schemas
-- Good testing coverage
-- Clear documentation
-- Proper governance controls
+[Positive data patterns observed — well-designed schemas, good testing, clear documentation, proper governance]
+```
 
 ## Relationship to Other Reviews
 

--- a/.claude/skills/review-security/SKILL.md
+++ b/.claude/skills/review-security/SKILL.md
@@ -58,53 +58,62 @@ Each agent should:
 After all agents complete:
 
 1. **Collect findings** from all 4 pillars
-2. **Apply confidence filter** - Remove findings below 50% confidence
-3. **Deduplicate** - Some issues may be flagged by multiple reviewers
-4. **Prioritize** - Sort by: HIGH confidence + HIGH severity first
-5. **Summarize** - Provide executive summary
+2. **Apply confidence filter** — Remove findings below 50% confidence
+3. **Deduplicate** — Some issues may be flagged by multiple reviewers
+4. **Aggregate maturity assessments** — Merge criteria assessments from all subagents into one maturity view
+5. **Determine maturity status per level:**
+   - All criteria ✅ → `pass` (✅)
+   - Mix of ✅ and ❌ → `partial` (⚠️)
+   - All criteria ❌ → `fail` (❌)
+   - Previous level not passed → `locked` (🔒)
+6. **Prioritize** findings by maturity level (HYG first), then severity + confidence (HIGH/HIGH → LOW/MED)
 
 ## Output Format
 
-### Executive Summary
+```markdown
+# Security Review — Maturity Assessment
 
-Brief overview of the review:
+## Maturity Status
 
-- Files reviewed
-- Total findings by severity and confidence
-- Top security concerns
-- STRIDE coverage summary
+| Level | Status | Summary |
+|-------|--------|---------|
+| Hygiene | ✅/⚠️/❌ | [one-line summary] |
+| Level 1 — Foundations | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 2 — Operational Maturity | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 3 — Excellence | ✅/⚠️/❌/🔒 | [one-line summary] |
 
-### Findings by Threat Category
+**Immediate Action:** [Top hygiene failure if hygiene not passed, else top action from next achievable level]
 
-#### Authentication & Authorization (Spoofing + Elevation)
+---
 
-[Findings from security-authn-authz agent]
+## Hygiene
 
-#### Data Protection (Information Disclosure + Tampering)
+[If any failures: list them with severity, confidence, STRIDE category, location, finding, recommendation]
+[If all pass: ✅ All hygiene criteria met]
 
-[Findings from security-data-protection agent]
+## [Next Achievable Level] — Detailed Assessment
 
-#### Input Validation (Injection)
+For each criterion:
+- ✅ **[Criterion]** — Evidence: `file:line` description
+- ❌ **[Criterion]** — Missing: what should exist
+- ⚠️ **[Criterion]** — Partial: what's there and what's missing
 
-[Findings from security-input-validation agent]
+## Higher Levels — Preview
 
-#### Audit & Resilience (Repudiation + DoS)
+> **Level [N+1]**: [Brief list of criteria — not yet assessed in detail]
+> **Level [N+2]**: [Brief list of criteria]
 
-[Findings from security-audit-resilience agent]
+---
 
-### Consolidated Action Items
+## Detailed Findings
 
-| Priority | Severity | Confidence | STRIDE | Location | Finding | Recommendation |
-| -------- | -------- | ---------- | ------ | -------- | ------- | -------------- |
-| 1 | HIGH | HIGH | ... | ... | ... | ... |
+| Priority | Severity | Maturity | Confidence | STRIDE | Location | Finding | Recommendation |
+|----------|----------|----------|------------|--------|----------|---------|----------------|
 
-### What's Secure
+## What's Good
 
-Note positive security patterns observed:
-
-- Good practices already in place
-- Effective security controls
-- Areas with strong coverage
+[Positive security patterns observed — good practices, effective controls, strong coverage areas]
+```
 
 ## Comparison with Built-in /security-review
 

--- a/.claude/skills/review-sre/SKILL.md
+++ b/.claude/skills/review-sre/SKILL.md
@@ -41,39 +41,58 @@ Each agent should:
 After all agents complete:
 
 1. **Collect findings** from all 4 pillars
-2. **Deduplicate** - Some issues may be flagged by multiple reviewers
-3. **Prioritize** - Sort by severity (HIGH → MEDIUM → LOW)
-4. **Summarize** - Provide executive summary
+2. **Deduplicate** — Some issues may be flagged by multiple reviewers
+3. **Aggregate maturity assessments** — Merge criteria assessments from all subagents into one maturity view
+4. **Determine maturity status per level:**
+   - All criteria ✅ → `pass` (✅)
+   - Mix of ✅ and ❌ → `partial` (⚠️)
+   - All criteria ❌ → `fail` (❌)
+   - Previous level not passed → `locked` (🔒)
+5. **Prioritize** findings by maturity level (HYG first), then severity (HIGH → LOW)
 
 ## Output Format
 
-### Executive Summary
+```markdown
+# SRE Review — Maturity Assessment
 
-Brief overview of the review:
-- Files reviewed
-- Total findings by severity
-- Top concerns
+## Maturity Status
 
-### Findings by Pillar
+| Level | Status | Summary |
+|-------|--------|---------|
+| Hygiene | ✅/⚠️/❌ | [one-line summary] |
+| Level 1 — Foundations | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 2 — Operational Maturity | ✅/⚠️/❌/🔒 | [one-line summary] |
+| Level 3 — Excellence | ✅/⚠️/❌/🔒 | [one-line summary] |
 
-#### Response
-[Findings from sre-response agent]
+**Immediate Action:** [Top hygiene failure if hygiene not passed, else top action from next achievable level]
 
-#### Observability
-[Findings from sre-observability agent]
+---
 
-#### Availability
-[Findings from sre-availability agent]
+## Hygiene
 
-#### Delivery
-[Findings from sre-delivery agent]
+[If any failures: list them with severity, category, location, finding, recommendation]
+[If all pass: ✅ All hygiene criteria met]
 
-### Consolidated Action Items
+## [Next Achievable Level] — Detailed Assessment
 
-| Priority | Finding | Location | Recommendation | Pillar |
-|----------|---------|----------|----------------|--------|
-| 1 | ... | ... | ... | ... |
+For each criterion:
+- ✅ **[Criterion]** — Evidence: `file:line` description
+- ❌ **[Criterion]** — Missing: what should exist
+- ⚠️ **[Criterion]** — Partial: what's there and what's missing
 
-### What's Good
+## Higher Levels — Preview
 
-Also note positive patterns observed - resilience patterns done well, good observability practices, etc.
+> **Level [N+1]**: [Brief list of criteria — not yet assessed in detail]
+> **Level [N+2]**: [Brief list of criteria]
+
+---
+
+## Detailed Findings
+
+| Priority | Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|----------|---------|----------------|
+
+## What's Good
+
+[Positive SRE patterns observed — resilience patterns done well, good observability practices, etc.]
+```

--- a/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/plan.md
+++ b/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/plan.md
@@ -1,0 +1,46 @@
+# Plan: Summary Reports with Maturity Scoring
+
+## Issue
+
+#13 — Add cascading maturity model (Hygiene → L1 → L2 → L3) to each review domain's sub-report.
+
+## Scope
+
+8 files modified, 0 new commands, 0 new subagents.
+
+## Tasks
+
+### Task 1: Save Spec Documentation
+Create this spec folder with plan, shape, and references.
+
+### Task 2–5: Update `_base.md` for Each Domain
+Add `## Maturity Model` section to each domain's base prompt with:
+- Domain-specific criteria table (Hygiene → L3)
+- Tagging rules (HYG/L1/L2/L3)
+- Criteria assessment instructions (Met/Not met/Partially met)
+- Updated output table with Maturity column
+
+| Task | Domain | File |
+|------|--------|------|
+| 2 | Architecture | `.claude/prompts/architecture/_base.md` |
+| 3 | SRE | `.claude/prompts/sre/_base.md` |
+| 4 | Security | `.claude/prompts/security/_base.md` |
+| 5 | Data | `.claude/prompts/data/_base.md` |
+
+### Task 6–9: Update `SKILL.md` for Each Domain
+Replace Step 3 (synthesis) and Output Format with maturity-aware structure:
+- Maturity status table (pass/partial/fail/locked)
+- Hygiene section (failures block all levels)
+- Next achievable level (detailed criterion assessment)
+- Higher level preview (brief)
+- Detailed findings table with Maturity column
+
+| Task | Domain | File |
+|------|--------|------|
+| 6 | Architecture | `.claude/skills/review-arch/SKILL.md` |
+| 7 | SRE | `.claude/skills/review-sre/SKILL.md` |
+| 8 | Security | `.claude/skills/review-security/SKILL.md` |
+| 9 | Data | `.claude/skills/review-data/SKILL.md` |
+
+### Task 10: Verify
+Run `/review-sre` against sample code to verify new output format.

--- a/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/references.md
+++ b/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/references.md
@@ -1,0 +1,25 @@
+# References: Summary Reports with Maturity Scoring
+
+## Files Studied
+
+### Base Prompts (to be modified)
+- `.claude/prompts/architecture/_base.md` — Architecture review base context with C4 zoom levels
+- `.claude/prompts/sre/_base.md` — SRE review base context with SEEMS/FaCTOR
+- `.claude/prompts/security/_base.md` — Security review base context with STRIDE/DREAD-lite
+- `.claude/prompts/data/_base.md` — Data review base context with DAMA DMBOK/Data Mesh
+
+### SKILL.md Orchestrators (to be modified)
+- `.claude/skills/review-arch/SKILL.md` — Architecture review orchestrator (4 zoom-level subagents)
+- `.claude/skills/review-sre/SKILL.md` — SRE review orchestrator (ROAD subagents)
+- `.claude/skills/review-security/SKILL.md` — Security review orchestrator (STRIDE subagents)
+- `.claude/skills/review-data/SKILL.md` — Data review orchestrator (4 pillar subagents)
+
+### Product Context
+- `agent-os/product/roadmap.md` — Defines the cascading maturity model (Hygiene → L1 → L2 → L3)
+
+## Design Decisions
+
+- Maturity criteria are domain-specific but follow the same 4-level structure across all domains
+- Subagent prompts do NOT change — they inherit maturity tagging from `_base.md`
+- The SKILL.md orchestrators handle maturity aggregation and the new output format
+- The headline cross-domain summary table is deferred to Issue #16 (`/review-all`)

--- a/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/shape.md
+++ b/agent-os/specs/2026-02-09-summary-reports-maturity-scoring/shape.md
@@ -1,0 +1,31 @@
+# Shape: Summary Reports with Maturity Scoring
+
+## Problem
+
+The 4 review domains (`/review-arch`, `/review-sre`, `/review-security`, `/review-data`) produce flat severity-ranked reports. There is no structured maturity assessment — findings aren't mapped to maturity levels, so teams can't see where they stand on a progression from baseline safety to excellence.
+
+## Appetite
+
+Small batch — changes are scoped to 8 existing files (4 `_base.md` + 4 `SKILL.md`). No new commands, no new subagents.
+
+## Solution
+
+Add a cascading maturity model (Hygiene → L1 → L2 → L3) to each domain. Each level requires the previous. The report structure changes from flat findings to maturity-aware output:
+
+1. **Maturity status table** — shows pass/partial/fail/locked per level
+2. **Hygiene section** — failures listed first (they block everything)
+3. **Next achievable level** — detailed criterion-by-criterion assessment
+4. **Higher level preview** — brief list of what comes next
+5. **Detailed findings table** — now includes a Maturity column (HYG/L1/L2/L3)
+
+## Rabbit Holes
+
+- **Cross-domain summary table**: That's `/review-all` (Issue #16), not this issue. Each domain sub-report stands alone.
+- **Subagent prompt changes**: Not needed — subagents inherit from `_base.md` and the maturity tagging instructions there are sufficient.
+- **Weighted scoring**: No numeric scores. Status is pass/partial/fail/locked — simple and unambiguous.
+
+## No-Gos
+
+- No changes to subagent prompts (they inherit `_base.md`)
+- No new CLI commands
+- No cross-domain aggregation (future issue)


### PR DESCRIPTION
## Summary

- Adds a 4-level cascading maturity model (Hygiene → L1 → L2 → L3) to all 4 review domains (`/review-arch`, `/review-sre`, `/review-security`, `/review-data`)
- Each domain's `_base.md` now includes domain-specific maturity criteria, tagging rules (HYG/L1/L2/L3), and criteria assessment instructions
- Each domain's `SKILL.md` orchestrator now produces maturity-aware reports: status table, hygiene section, next achievable level detail, higher level preview, and findings with maturity column
- Spec documentation added to `agent-os/specs/2026-02-09-summary-reports-maturity-scoring/`

## Test plan

- [x] Run `/review-sre` against this codebase — verified maturity status table, hygiene section, detailed assessment, findings with Maturity column, and higher level preview all render correctly
- [ ] Run `/review-arch` and verify maturity assessment appears
- [ ] Run `/review-security` and verify maturity assessment appears
- [ ] Run `/review-data` and verify maturity assessment appears
- [ ] Confirm hygiene failures block higher levels (locked indicator)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)