### PR TITLE
Rewrite maturity model: universal Hygiene gate with outcome-based levels

### DIFF
--- a/.claude/agents/arch-code.md
+++ b/.claude/agents/arch-code.md
@@ -41,8 +41,8 @@ Read the detailed checklist from `.claude/prompts/architecture/code.md`.
 
 ## Output Format
 
-| Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | ---------- | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Code | file:line | Issue | How to fix |
+| Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+| -------- | -------- | ---------- | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Code | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/arch-landscape.md
+++ b/.claude/agents/arch-landscape.md
@@ -51,8 +51,8 @@ For smaller projects (monolith, single service), this level may return few or no
 
 ## Output Format
 
-| Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | ---------- | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Landscape | file:line or system-level | Issue | How to fix |
+| Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+| -------- | -------- | ---------- | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Landscape | file:line or system-level | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/arch-service.md
+++ b/.claude/agents/arch-service.md
@@ -42,8 +42,8 @@ Read the detailed checklist from `.claude/prompts/architecture/service.md`.
 
 ## Output Format
 
-| Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | ---------- | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Service | file:line | Issue | How to fix |
+| Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+| -------- | -------- | ---------- | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Service | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/arch-system.md
+++ b/.claude/agents/arch-system.md
@@ -42,8 +42,8 @@ Read the detailed checklist from `.claude/prompts/architecture/system.md`.
 
 ## Output Format
 
-| Severity | Zoom Level | Location | Finding | Recommendation |
-| -------- | ---------- | -------- | ------- | -------------- |
-| HIGH/MED/LOW | System | file:line | Issue | How to fix |
+| Severity | Maturity | Zoom Level | Location | Finding | Recommendation |
+| -------- | -------- | ---------- | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | System | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/data-architecture.md
+++ b/.claude/agents/data-architecture.md
@@ -40,8 +40,8 @@ Read the detailed checklist from `.claude/prompts/data/architecture.md`.
 
 ## Output Format
 
-| Severity | Pillar | Location | Finding | Recommendation |
-| -------- | ------ | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Architecture | file:line | Issue | How to fix |
+| Severity | Maturity | Pillar | Location | Finding | Recommendation |
+| -------- | -------- | ------ | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Architecture | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/data-engineering.md
+++ b/.claude/agents/data-engineering.md
@@ -41,8 +41,8 @@ Read the detailed checklist from `.claude/prompts/data/engineering.md`.
 
 ## Output Format
 
-| Severity | Pillar | Location | Finding | Recommendation |
-| -------- | ------ | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Engineering | file:line | Issue | How to fix |
+| Severity | Maturity | Pillar | Location | Finding | Recommendation |
+| -------- | -------- | ------ | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Engineering | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/data-governance.md
+++ b/.claude/agents/data-governance.md
@@ -33,15 +33,15 @@ Read the detailed checklist from `.claude/prompts/data/governance.md`.
 
 - PII in logs, debug tables, or analytics without masking
 - Missing data classification labels
-- No retention policy defined (data grows forever)
+- No evidence of lifecycle management in code (TTL columns, partition expiration, soft-delete flags, retention-driven pruning jobs)
 - Missing backup strategy or DR documentation
 - Unclear data ownership (no business/technical owner)
 - Lineage not captured or documented
 
 ## Output Format
 
-| Severity | Pillar | Location | Finding | Recommendation |
-| -------- | ------ | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Governance | file:line | Issue | How to fix |
+| Severity | Maturity | Pillar | Location | Finding | Recommendation |
+| -------- | -------- | ------ | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Governance | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/data-quality.md
+++ b/.claude/agents/data-quality.md
@@ -41,8 +41,8 @@ Read the detailed checklist from `.claude/prompts/data/quality.md`.
 
 ## Output Format
 
-| Severity | Pillar | Location | Finding | Recommendation |
-| -------- | ------ | -------- | ------- | -------------- |
-| HIGH/MED/LOW | Quality | file:line | Issue | How to fix |
+| Severity | Maturity | Pillar | Location | Finding | Recommendation |
+| -------- | -------- | ------ | -------- | ------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Quality | file:line | Issue | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/security-audit-resilience.md
+++ b/.claude/agents/security-audit-resilience.md
@@ -45,8 +45,8 @@ For DoS findings, require HIGH confidence (>80%) with clear exploit path:
 
 ## Output Format
 
-| Severity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
-| -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
-| HIGH/MED/LOW | HIGH/MED | R or D | file:line | Issue | How to exploit | How to fix |
+| Severity | Maturity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
+| -------- | -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | HIGH/MED | R or D | file:line | Issue | How to exploit | How to fix |
 
 Focus on HIGH severity + HIGH confidence items first. Be specific and actionable.

--- a/.claude/agents/security-authn-authz.md
+++ b/.claude/agents/security-authn-authz.md
@@ -40,8 +40,8 @@ Only report findings with >50% confidence. Prioritize HIGH confidence (>80%) fin
 
 ## Output Format
 
-| Severity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
-| -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
-| HIGH/MED/LOW | HIGH/MED | S or E | file:line | Issue | How to exploit | How to fix |
+| Severity | Maturity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
+| -------- | -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | HIGH/MED | S or E | file:line | Issue | How to exploit | How to fix |
 
 Focus on HIGH severity + HIGH confidence items first. Be specific and actionable.

--- a/.claude/agents/security-data-protection.md
+++ b/.claude/agents/security-data-protection.md
@@ -40,8 +40,8 @@ Only report findings with >50% confidence. Prioritize HIGH confidence (>80%) fin
 
 ## Output Format
 
-| Severity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
-| -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
-| HIGH/MED/LOW | HIGH/MED | I or T | file:line | Issue | How to exploit | How to fix |
+| Severity | Maturity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
+| -------- | -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | HIGH/MED | I or T | file:line | Issue | How to exploit | How to fix |
 
 Focus on HIGH severity + HIGH confidence items first. Be specific and actionable.

--- a/.claude/agents/security-input-validation.md
+++ b/.claude/agents/security-input-validation.md
@@ -49,8 +49,8 @@ Injection vulnerabilities are often HIGH confidence when you can trace user inpu
 
 ## Output Format
 
-| Severity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
-| -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
-| HIGH/MED/LOW | HIGH/MED | T | file:line | Issue | How to exploit | How to fix |
+| Severity | Maturity | Confidence | STRIDE | Location | Finding | Exploit Scenario | Recommendation |
+| -------- | -------- | ---------- | ------ | -------- | ------- | ---------------- | -------------- |
+| HIGH/MED/LOW | HYG/L1/L2/L3 | HIGH/MED | T | file:line | Issue | How to exploit | How to fix |
 
 Focus on HIGH severity + HIGH confidence items first. Be specific and actionable.

--- a/.claude/agents/sre-availability.md
+++ b/.claude/agents/sre-availability.md
@@ -35,8 +35,8 @@ Read `.claude/prompts/sre/availability.md` for the complete review checklist.
 
 ## Output Format
 
-| Severity | Category | Location | Finding | Recommendation |
-|----------|----------|----------|---------|----------------|
-| HIGH/MED/LOW | Availability area | file:line | Issue found | How to fix |
+| Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|---------|----------------|
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Availability area | file:line | Issue found | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/sre-delivery.md
+++ b/.claude/agents/sre-delivery.md
@@ -31,8 +31,8 @@ Read `.claude/prompts/sre/delivery.md` for the complete review checklist.
 
 ## Output Format
 
-| Severity | Category | Location | Finding | Recommendation |
-|----------|----------|----------|---------|----------------|
-| HIGH/MED/LOW | Delivery area | file:line | Issue found | How to fix |
+| Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|---------|----------------|
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Delivery area | file:line | Issue found | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/sre-observability.md
+++ b/.claude/agents/sre-observability.md
@@ -32,8 +32,8 @@ Read `.claude/prompts/sre/observability.md` for the complete review checklist.
 
 ## Output Format
 
-| Severity | Category | Location | Finding | Recommendation |
-|----------|----------|----------|---------|----------------|
-| HIGH/MED/LOW | Observability area | file:line | Issue found | How to fix |
+| Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|---------|----------------|
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Observability area | file:line | Issue found | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/agents/sre-response.md
+++ b/.claude/agents/sre-response.md
@@ -31,8 +31,8 @@ Read `.claude/prompts/sre/response.md` for the complete review checklist.
 
 ## Output Format
 
-| Severity | Category | Location | Finding | Recommendation |
-|----------|----------|----------|---------|----------------|
-| HIGH/MED/LOW | Response area | file:line | Issue found | How to fix |
+| Severity | Maturity | Category | Location | Finding | Recommendation |
+|----------|----------|----------|----------|---------|----------------|
+| HIGH/MED/LOW | HYG/L1/L2/L3 | Response area | file:line | Issue found | How to fix |
 
 Focus on HIGH severity items first. Be specific and actionable.

--- a/.claude/prompts/architecture/_base.md
+++ b/.claude/prompts/architecture/_base.md
@@ -104,33 +104,60 @@ These apply at all zoom levels:
 
 ## Maturity Model
 
-Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+### Hygiene Gate
 
-| Level | Criteria for Architecture |
-|-------|--------------------------|
-| **Hygiene** | No circular dependencies between modules. No shared mutable state across boundaries. No god classes or modules with unbounded responsibility. |
-| **Level 1 — Foundations** | Clear module boundaries with explicit public APIs. SRP followed at class/module level. Dependencies flow inward (infrastructure depends on domain, not vice versa). Architecture diagrams published and current. |
-| **Level 2 — Operational Maturity** | DDD tactical patterns applied (aggregates, value objects, domain events). Bounded contexts explicit with defined integration contracts. ADRs document key architectural decisions. Stability patterns (circuit breakers, bulkheads) applied at integration points. |
-| **Level 3 — Excellence** | Fitness functions validate architectural characteristics automatically. Context maps document cross-system relationships. EIP patterns govern inter-system messaging. Evolutionary architecture — changes are safe, incremental, and reversible. |
+The Hygiene flag identifies findings that could cause lasting damage to the organisation's reputation, trust, or legal standing. A Hygiene breach is a call to action — it trumps maturity progression.
+
+Any finding at any maturity level is promoted to Hygiene if it passes any of these tests:
+
+| Test | Question |
+|------|----------|
+| **Irreversible** | If this goes wrong, can the damage be undone? (data loss, leaked credentials, corrupted state, mass mis-communication) |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? (thread exhaustion, deployment coupling, resource starvation) |
+| **Regulated** | Does this violate a legal or compliance obligation? (PII exposure, accessibility law, false claims, financial reporting) |
+
+Any "yes" promotes the finding to `HYG`, regardless of its maturity level.
+
+**Examples in Architecture:** Two services writing directly to the same database tables (irreversible corruption). Synchronous circular dependency chain where one failure cascades to all participants (total). Deployment requires all services released simultaneously (total).
+
+### Maturity Levels
+
+Levels are cumulative — each builds on the previous.
+
+| Level | Observable Criteria |
+|-------|-------------------|
+| **L1 — Foundations** | Module boundaries are explicit with defined public interfaces. Dependencies flow inward (infrastructure depends on domain, not vice versa). Components can be tested in isolation. |
+| **L2 — Hardening** | Integration contracts are defined between boundaries. Design decisions are documented with rationale and trade-offs. Failure at integration points is contained, not propagated. |
+| **L3 — Excellence** | Architectural constraints are validated automatically in CI. Cross-boundary relationships are documented and kept current. Changes can be made incrementally without coordinated deployment. |
 
 ### Tagging Rules
 
 For each finding, add a `Maturity` column to your output table:
-- `HYG` — Hygiene violation (baseline safety failure)
+
+- `HYG` — Finding triggers the Hygiene gate (any test = yes). **Report these first.**
 - `L1` — Level 1 criteria gap
 - `L2` — Level 2 criteria gap
 - `L3` — Level 3 criteria gap
 
+A finding's maturity level reflects which level the practice belongs to. If the same finding also triggers the Hygiene gate, tag it `HYG` — the Hygiene flag overrides the level.
+
 ### Criteria Assessment
 
 After your findings table, add a **Maturity Assessment** section:
+
+**First, assess the Hygiene gate:**
+- State whether any findings triggered the Hygiene gate
+- If yes, list each with the test it failed (Irreversible / Total / Regulated)
+- Hygiene breaches are the primary call to action — flag them for immediate attention
+
+**Then, assess each maturity level:**
 
 For each criterion at each level, state:
 - ✅ **Met** — Evidence found in code (cite location)
 - ❌ **Not met** — What's missing (cite what should exist)
 - ⚠️ **Partially met** — Some evidence, gaps remain
 
-Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+Start from L1 and work up. Stop providing detailed assessment after the first level with any ❌.
 
 ---
 

--- a/.claude/prompts/data/_base.md
+++ b/.claude/prompts/data/_base.md
@@ -79,35 +79,60 @@ This review framework synthesizes principles from:
 
 ## Maturity Model
 
-Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+### Hygiene Gate
 
-| Level | Criteria for Data |
-|-------|------------------|
-| **Hygiene** | No missing PII masking in outputs or logs. No breaking schema changes without versioning. No silent data loss (dropped records without error). No unhandled nulls in joins or aggregations. |
-| **Level 1 — Foundations** | Schema documented with field descriptions. Ownership defined for each data asset. Basic data validation (type checks, not-null constraints, referential integrity). Idempotent processing for all pipelines. |
-| **Level 2 — Operational Maturity** | Freshness SLOs defined and monitored. Data contracts between producers and consumers. Lineage tracked from source to consumption. Quality monitoring with automated anomaly detection. Reconciliation between source and target. |
-| **Level 3 — Excellence** | Bitemporality for audit-critical data. Self-serve discovery catalog. Automated reconciliation with alerting. Data mesh patterns — domain-owned data products with interoperability standards. |
+The Hygiene flag identifies findings that could cause lasting damage to the organisation's reputation, trust, or legal standing. A Hygiene breach is a call to action — it trumps maturity progression.
+
+Any finding at any maturity level is promoted to Hygiene if it passes any of these tests:
+
+| Test | Question |
+|------|----------|
+| **Irreversible** | If this goes wrong, can the damage be undone? (data loss, leaked credentials, corrupted state, mass mis-communication) |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? (thread exhaustion, deployment coupling, resource starvation) |
+| **Regulated** | Does this violate a legal or compliance obligation? (PII exposure, accessibility law, false claims, financial reporting) |
+
+Any "yes" promotes the finding to `HYG`, regardless of its maturity level.
+
+**Examples in Data:** PII written to application logs or uncontrolled outputs (regulated — cannot be unlogged from aggregated stores). Pipeline silently drops records on schema mismatch with no error (irreversible — undetected data loss). Migration script with unbounded DELETE or TRUNCATE (irreversible).
+
+### Maturity Levels
+
+Levels are cumulative — each builds on the previous.
+
+| Level | Observable Criteria |
+|-------|-------------------|
+| **L1 — Foundations** | Schemas are documented with field-level descriptions. Each data asset has a defined owner. Input data is validated (types, constraints, referential integrity). Processing is idempotent — re-runs produce identical results. |
+| **L2 — Hardening** | Freshness expectations are defined and monitored. Contracts exist between producers and consumers. Data can be traced from source to destination. Quality is monitored with automated checks. Source and target are reconciled. |
+| **L3 — Excellence** | Temporal changes are tracked for audit-critical data. Data assets are discoverable without tribal knowledge. Reconciliation runs automatically with alerting on divergence. |
 
 ### Tagging Rules
 
 For each finding, add a `Maturity` column to your output table:
 
-- `HYG` — Hygiene violation (baseline safety failure)
+- `HYG` — Finding triggers the Hygiene gate (any test = yes). **Report these first.**
 - `L1` — Level 1 criteria gap
 - `L2` — Level 2 criteria gap
 - `L3` — Level 3 criteria gap
+
+A finding's maturity level reflects which level the practice belongs to. If the same finding also triggers the Hygiene gate, tag it `HYG` — the Hygiene flag overrides the level.
 
 ### Criteria Assessment
 
 After your findings table, add a **Maturity Assessment** section:
 
-For each criterion at each level, state:
+**First, assess the Hygiene gate:**
+- State whether any findings triggered the Hygiene gate
+- If yes, list each with the test it failed (Irreversible / Total / Regulated)
+- Hygiene breaches are the primary call to action — flag them for immediate attention
 
+**Then, assess each maturity level:**
+
+For each criterion at each level, state:
 - ✅ **Met** — Evidence found in code (cite location)
 - ❌ **Not met** — What's missing (cite what should exist)
 - ⚠️ **Partially met** — Some evidence, gaps remain
 
-Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+Start from L1 and work up. Stop providing detailed assessment after the first level with any ❌.
 
 ---
 

--- a/.claude/prompts/security/_base.md
+++ b/.claude/prompts/security/_base.md
@@ -76,35 +76,60 @@ A valid security finding must have:
 
 ## Maturity Model
 
-Tag each finding with the maturity level it belongs to. Levels are cumulative — each requires the previous.
+### Hygiene Gate
 
-| Level | Criteria for Security |
-|-------|----------------------|
-| **Hygiene** | No SQL injection or command injection vectors. No hardcoded secrets or credentials in source. Authentication enforced on all protected routes. No path traversal vulnerabilities. |
-| **Level 1 — Foundations** | Auth/authz model exists and is consistently applied. Input validation on all external entry points. Secrets managed via vault or environment (not code). Session management follows best practices (expiry, rotation). |
-| **Level 2 — Operational Maturity** | STRIDE threat model coverage across all components. Audit trails for security-relevant actions. Rate limiting on authentication and public endpoints. Least-privilege defaults for all roles. Threat modelling documented per service. |
-| **Level 3 — Excellence** | Automated security testing in CI pipeline (SAST/DAST). Crypto-agility — encryption algorithms configurable, not hardcoded. Security chaos testing (fault injection for auth failures). Dependency vulnerability scanning automated. |
+The Hygiene flag identifies findings that could cause lasting damage to the organisation's reputation, trust, or legal standing. A Hygiene breach is a call to action — it trumps maturity progression.
+
+Any finding at any maturity level is promoted to Hygiene if it passes any of these tests:
+
+| Test | Question |
+|------|----------|
+| **Irreversible** | If this goes wrong, can the damage be undone? (data loss, leaked credentials, corrupted state, mass mis-communication) |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? (thread exhaustion, deployment coupling, resource starvation) |
+| **Regulated** | Does this violate a legal or compliance obligation? (PII exposure, accessibility law, false claims, financial reporting) |
+
+Any "yes" promotes the finding to `HYG`, regardless of its maturity level.
+
+**Examples in Security:** User input concatenated into SQL or OS commands (irreversible — data breach or RCE). API keys or credentials committed in source code (irreversible — once pushed, compromised permanently). Authentication check missing on a destructive endpoint (irreversible).
+
+### Maturity Levels
+
+Levels are cumulative — each builds on the previous.
+
+| Level | Observable Criteria |
+|-------|-------------------|
+| **L1 — Foundations** | Authentication and authorisation are applied consistently on all protected paths. External input is validated before processing. Secrets are loaded from environment or external store, not source. Sessions have explicit expiry and rotation. |
+| **L2 — Hardening** | Security-relevant actions produce audit records. Exposed endpoints enforce rate limits. Roles default to least privilege; access is granted explicitly. Error responses do not leak internal state or stack traces. |
+| **L3 — Excellence** | Security checks run automatically in the build pipeline. Encryption parameters are configurable, not hardcoded. Dependencies are scanned for known vulnerabilities automatically. |
 
 ### Tagging Rules
 
 For each finding, add a `Maturity` column to your output table:
 
-- `HYG` — Hygiene violation (baseline safety failure)
+- `HYG` — Finding triggers the Hygiene gate (any test = yes). **Report these first.**
 - `L1` — Level 1 criteria gap
 - `L2` — Level 2 criteria gap
 - `L3` — Level 3 criteria gap
+
+A finding's maturity level reflects which level the practice belongs to. If the same finding also triggers the Hygiene gate, tag it `HYG` — the Hygiene flag overrides the level.
 
 ### Criteria Assessment
 
 After your findings table, add a **Maturity Assessment** section:
 
-For each criterion at each level, state:
+**First, assess the Hygiene gate:**
+- State whether any findings triggered the Hygiene gate
+- If yes, list each with the test it failed (Irreversible / Total / Regulated)
+- Hygiene breaches are the primary call to action — flag them for immediate attention
 
+**Then, assess each maturity level:**
+
+For each criterion at each level, state:
 - ✅ **Met** — Evidence found in code (cite location)
 - ❌ **Not met** — What's missing (cite what should exist)
 - ⚠️ **Partially met** — Some evidence, gaps remain
 
-Start from Hygiene and work up. Stop providing detailed assessment after the first level with any ❌.
+Start from L1 and work up. Stop providing detailed assessment after the first level with any ❌.
 
 ---
 

--- a/.claude/prompts/sre/observability.md
+++ b/.claude/prompts/sre/observability.md
@@ -53,11 +53,11 @@ You can't fix what you can't see. Observability is about:
 - [ ] Can you see retry attempts and their outcomes?
 - [ ] Can you correlate logs, metrics, and traces?
 
-### Alerting Readiness
+### Signal Presence
 
-- [ ] Are there metrics suitable for alerting? (not too noisy, not too quiet)
-- [ ] Can you distinguish between symptoms and causes?
-- [ ] Are there leading indicators? (queue growth before timeout)
+- [ ] Do critical failure paths emit a metric or log that could be alerted on?
+- [ ] Can you distinguish between symptoms and causes from emitted signals?
+- [ ] Are there leading indicators emitted? (queue depth, connection pool usage, error rate changes)
 
 ## SEEMS Focus for Observability
 


### PR DESCRIPTION
## Summary

- Replace domain-specific Hygiene checklists with a universal promotion gate based on three consequence-severity tests: **Irreversible**, **Total**, **Regulated**
- Rewrite L1/L2/L3 criteria as observable outcomes — no technique names (no "DDD", "SAST/DAST", "circuit breaker", "data mesh", "SEEMS/FaCTOR")
- Hygiene Gate section (rationale + 3-test table + promotion rule) is identical across all four domains; each domain retains unique examples and L1/L2/L3 criteria
- Fix pre-existing SRE heading inconsistency (`### Output Format` → `## Output Format`)
- Add `Maturity` column (`HYG/L1/L2/L3`) to output tables in all 16 sub-agent files, syncing with base prompt and skill orchestrator schemas
- Refine `data-governance` agent to look for evidence of lifecycle management in code (TTL columns, partition expiration, soft-delete flags) rather than expecting retention policy documents
- Refine `sre-observability` checklist from "metrics suitable for alerting" to "signal presence" — whether critical failure paths emit observable signals

Stacked on #14 (`feature/13-maturity-scoring`).

## Test plan

- [ ] Verify Hygiene Gate is byte-identical across architecture, sre, security, data `_base.md`
- [ ] Verify no technique names leak into L1/L2/L3 criteria
- [ ] Verify each domain has unique Hygiene examples and unique L1/L2/L3 criteria
- [ ] Verify output format tables are unchanged per domain
- [ ] Verify all 16 sub-agent output tables include the `Maturity` column matching their parent base prompt schema
- [ ] Run a review against a sample codebase and confirm HYG/L1/L2/L3 tagging works end-to-end from sub-agent through to orchestrator synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)